### PR TITLE
feat: add primitive substeps in flow editor

### DIFF
--- a/packages/web/src/graphql/queries/get-apps.ts
+++ b/packages/web/src/graphql/queries/get-apps.ts
@@ -58,6 +58,11 @@ export const GET_APPS = gql`
         description
         subSteps {
           name
+          arguments {
+            name
+            type
+            required
+          }
         }
       }
       actions {
@@ -66,6 +71,11 @@ export const GET_APPS = gql`
         description
         subSteps {
           name
+          arguments {
+            name
+            type
+            required
+          }
         }
       }
     }


### PR DESCRIPTION
Now, we have substeps visible upon selecting an action. However, there is no implementation for substeps yet. Therefore, there'll be nothing expanding once a substep is expanded.

![image](https://user-images.githubusercontent.com/1263419/151723657-5038a210-d180-4c95-972d-418378bef8e9.png)
