### PR TITLE
chore(docs): make baseUrl configurable

### DIFF
--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -9,7 +9,7 @@ const config = {
   title: 'Automatisch Docs',
   tagline: 'Automatisch Docs',
   url: 'https://docs.automatisch.io',
-  baseUrl: '/',
+  baseUrl: process.env.BASE_URL ? process.env.BASE_URL : '/',
   onBrokenLinks: 'warn',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',


### PR DESCRIPTION
Use BASE_URL environment variable to configure baseUrl in docusaurus config. Otherwise, `/` is used by default.