### PR TITLE
fix: keep this in diagnosticInfo timeout

### DIFF
--- a/packages/backend/src/helpers/telemetry/index.ts
+++ b/packages/backend/src/helpers/telemetry/index.ts
@@ -139,7 +139,7 @@ class Telemetry {
       },
     });
 
-    setTimeout(this.diagnosticInfo, SIX_HOURS_IN_MILLISECONDS);
+    setTimeout(() => this.diagnosticInfo(), SIX_HOURS_IN_MILLISECONDS);
   }
 }
 


### PR DESCRIPTION
`this` was lost when `Telemetry#diagnosticInfo` was invoked in setTimeout. 

![image](https://user-images.githubusercontent.com/1263419/181200106-527444c5-e661-4577-a824-b0d8de633ea8.png)

This branch fixes the problem by encapsulating the function call with an arrow function.