### PR TITLE
feat: add pagination on /flows

### DIFF
--- a/packages/web/src/components/AppFlows/index.tsx
+++ b/packages/web/src/components/AppFlows/index.tsx
@@ -10,12 +10,15 @@ type AppFlowsProps = {
 
 export default function AppFlows(props: AppFlowsProps): React.ReactElement {
   const { appKey } = props;
-  const { data } = useQuery(GET_FLOWS, { variables: { appKey }});
-  const appFlows: IFlow[] = data?.getFlows || [];
+  const { data } = useQuery(GET_FLOWS, { variables: { appKey, limit: 100, offset: 0 }});
+  const getFlows = data?.getFlows || {};
+  const { edges } = getFlows;
+
+  const appFlows: IFlow[] = edges?.map(({ node }: { node: IFlow }) => node);
 
   return (
     <>
-      {appFlows.map((appFlow: IFlow) => (
+      {appFlows?.map((appFlow: IFlow) => (
         <AppFlowRow key={appFlow.id} flow={appFlow} />
       ))}
     </>

--- a/packages/web/src/graphql/queries/get-flows.ts
+++ b/packages/web/src/graphql/queries/get-flows.ts
@@ -1,10 +1,18 @@
 import { gql } from '@apollo/client';
 
 export const GET_FLOWS = gql`
-  query GetFlows($appKey: String) {
-    getFlows(appKey: $appKey) {
-      id
-      name
+  query GetFlows($limit: Int!, $offset: Int!, $appKey: String) {
+    getFlows(limit: $limit, offset: $offset, appKey: $appKey) {
+      pageInfo {
+        currentPage
+        totalPages
+      }
+      edges {
+        node {
+          id
+          name
+        }
+      }
     }
   }
 `;


### PR DESCRIPTION
As of this branch and until #383, the search function on /flows will not expectedly function as it only filters the list on the client-side. Also, on the app flows page, there'll be an assumption of `limit = 100` without pagination for now.

fixes #382