### PR TITLE
fix: polish top whitespace in executions title

### DIFF
--- a/packages/web/src/pages/Executions/index.tsx
+++ b/packages/web/src/pages/Executions/index.tsx
@@ -43,7 +43,7 @@ export default function Executions(): React.ReactElement {
     <Box sx={{ py: 3 }}>
       <Container>
         <Grid container sx={{ mb: [2, 5] }} columnSpacing={1.5} rowSpacing={3}>
-          <Grid container item xs sm alignItems="center" order={{ xs: 0 }}>
+          <Grid container item xs sm alignItems="center" order={{ xs: 0, height: 80 }}>
             <PageTitle>{formatMessage('executions.title')}</PageTitle>
           </Grid>
         </Grid>


### PR DESCRIPTION
This change aims to have titles at the same vertical alignment across pages.