### PR TITLE
fix the docs link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ There are other existing solutions in the market, like Zapier and Integromat, so
 
 ## Documentation
 
-The official documentation can be found here: [https://automatisch.io/docs](https://automatisch.io/docs)
+The official documentation can be found here: [https://automatisch.io/docs](https://automatisch.io/docs/)
 
 ## Installation
 


### PR DESCRIPTION
### The problem
When you go to `https://automatisch.io/docs`, it takes you to `https://automatisch.io/docs.html` which shows -> 

<img width="1510" alt="Screenshot 2022-10-12 at 13 38 36" src="https://user-images.githubusercontent.com/10273427/195323659-bf32f135-dc29-4183-bf5e-bd54e738159e.png">

If you click take me home it takes you to `https://automatisch.io/docs/` which shows the page for **what is automatisch**

Maybe this can be fixed in the docs side but wanted to open this pr to get the link to open the right page 🤓 
