### PR TITLE
feat: show doc info in auth dialog in editor

### DIFF
--- a/packages/web/src/graphql/queries/get-apps.ts
+++ b/packages/web/src/graphql/queries/get-apps.ts
@@ -15,6 +15,7 @@ export const GET_APPS = gql`
       key
       iconUrl
       docUrl
+      authDocUrl
       primaryColor
       connectionCount
       supportsConnections


### PR DESCRIPTION
The information about adding a connection in the add new connection dialog on the editor page is added.

**before**
![image](https://user-images.githubusercontent.com/1263419/201722071-b172e81e-cfa3-4c55-82e3-a7ce0b2b7167.png)

**after**
![image](https://user-images.githubusercontent.com/1263419/201722000-fe60e6f3-b54e-43b7-ba58-434780250f1a.png)
