### PR TITLE
fix: use actual DB name in wait for postgres script

### DIFF
--- a/docker/images/main/wait-for-postgres.sh
+++ b/docker/images/main/wait-for-postgres.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-until psql -h "$POSTGRES_HOST" -U "$POSTGRES_USERNAME" -d "$POSTGRES_HOST" -c '\q'; do
+until psql -h "$POSTGRES_HOST" -U "$POSTGRES_USERNAME" -d "$POSTGRES_DATABASE" -c '\q'; do
   >&2 echo "Waiting for Postgres to be ready..."
   sleep 1
 done

--- a/docker/images/worker/wait-for-postgres.sh
+++ b/docker/images/worker/wait-for-postgres.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-until psql -h "$POSTGRES_HOST" -U "$POSTGRES_USERNAME" -d "$POSTGRES_HOST" -c '\q'; do
+until psql -h "$POSTGRES_HOST" -U "$POSTGRES_USERNAME" -d "$POSTGRES_DATABASE" -c '\q'; do
   >&2 echo "Waiting for Postgres to be ready..."
   sleep 1
 done


### PR DESCRIPTION
resolves #723

@ksurl, we think this may be the cause, as you mentioned. Could you please give this a try if it helps you out?