### PR TITLE
fix: update compose image tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,7 @@ services:
   main:
     build:
       context: ./docker
-      tags:
-        - automatisch/automatisch
+    image: automatisch/automatisch
     ports:
       - '3000:3000'
     depends_on:
@@ -27,8 +26,7 @@ services:
   worker:
     build:
       context: ./docker
-      tags:
-        - automatisch/automatisch
+    image: automatisch/automatisch
     depends_on:
       - main
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   main:
     build:
       context: ./docker
-    image: automatisch/automatisch
+    image: automatischio/automatisch
     ports:
       - '3000:3000'
     depends_on:
@@ -26,7 +26,7 @@ services:
   worker:
     build:
       context: ./docker
-    image: automatisch/automatisch
+    image: automatischio/automatisch
     depends_on:
       - main
     environment:


### PR DESCRIPTION
local build was using automatisch-main and automatisch-worker as the build tags despite setting the tags.
switched to setting the image name which is used by docker compose build.