### PR TITLE
docs(todoist): restructure trigger and add in nav

### DIFF
--- a/packages/docs/pages/.vitepress/config.js
+++ b/packages/docs/pages/.vitepress/config.js
@@ -151,6 +151,16 @@ export default defineConfig({
           ],
         },
         {
+          text: 'Todoist',
+          collapsible: true,
+          collapsed: true,
+          items: [
+            { text: 'Triggers', link: '/apps/todoist/triggers' },
+            { text: 'Actions', link: '/apps/todoist/actions' },
+            { text: 'Connection', link: '/apps/todoist/connection' },
+          ],
+        },
+        {
           text: 'Twilio',
           collapsible: true,
           collapsed: true,

--- a/packages/docs/pages/apps/todoist/triggers.md
+++ b/packages/docs/pages/apps/todoist/triggers.md
@@ -1,8 +1,8 @@
 ---
 favicon: /favicons/todoist.svg
 items:
-  - name: Create Task
-    desc: Creates a task in Todoist.
+  - name: Get Tasks
+    desc: Finds tasks in Todoist, optionally matching specified parameters.
 ---
 
 <script setup>

--- a/packages/docs/pages/guide/available-apps.md
+++ b/packages/docs/pages/guide/available-apps.md
@@ -19,6 +19,7 @@ Following integrations are currently supported by Automatisch.
 - [SMTP](/apps/smtp/actions)
 - [Stripe](/apps/stripe/triggers)
 - [Telegram](/apps/telegram-bot/actions)
+- [Todoist](/apps/todoist/triggers)
 - [Twilio](/apps/twilio/triggers)
 - [Twitter](/apps/twitter/triggers)
 - [Typeform](/apps/typeform/triggers)


### PR DESCRIPTION
I have overlooked some cases in the documentation review of #826. Therefore, I have created this pull request to;

- Add it to the available apps page
- Move the "create task" trigger from the actions page to the triggers page
- Add it into the navigation configuration as we manually configure the nav