### PR TITLE
feat(twitter): add search user action

### DIFF
--- a/packages/backend/src/apps/twitter/actions/index.ts
+++ b/packages/backend/src/apps/twitter/actions/index.ts
@@ -1,3 +1,4 @@
 import createTweet from './create-tweet';
+import searchUser from './search-user';
 
-export default [createTweet];
+export default [createTweet, searchUser];

--- a/packages/backend/src/apps/twitter/actions/search-user/index.ts
+++ b/packages/backend/src/apps/twitter/actions/search-user/index.ts
@@ -1,0 +1,30 @@
+import defineAction from '../../../../helpers/define-action';
+
+export default defineAction({
+  name: 'Search user',
+  key: 'searchUser',
+  description: 'Search a user on Twitter',
+  arguments: [
+    {
+      label: 'Username',
+      key: 'username',
+      type: 'string' as const,
+      required: true,
+      description: 'The username of the Twitter user you want to search for',
+      variables: true,
+    },
+  ],
+
+  async run($) {
+    const { data } = await $.http.get(`/2/users/by/username/${$.step.parameters.username}`, {
+      params: {
+        expansions: 'pinned_tweet_id',
+        'tweet.fields': 'attachments,author_id,context_annotations,conversation_id,created_at,edit_controls,entities,geo,id,in_reply_to_user_id,lang,non_public_metrics,public_metrics,organic_metrics,promoted_metrics,possibly_sensitive,referenced_tweets,reply_settings,source,text,withheld',
+        'user.fields': 'created_at,description,entities,id,location,name,pinned_tweet_id,profile_image_url,protected,public_metrics,url,username,verified,verified_type,withheld'
+      }
+    });
+    $.setActionItem({
+      raw: data.data
+    });
+  },
+});

--- a/packages/backend/src/apps/twitter/common/add-auth-header.ts
+++ b/packages/backend/src/apps/twitter/common/add-auth-header.ts
@@ -1,4 +1,5 @@
 import { Token } from 'oauth-1.0a';
+import { URLSearchParams } from 'node:url';
 import { IJSONObject, TBeforeRequest } from '@automatisch/types';
 import oauthClient from './oauth-client';
 
@@ -9,15 +10,24 @@ type RequestDataType = {
 };
 
 const addAuthHeader: TBeforeRequest = ($, requestConfig) => {
-  const { url, method, data } = requestConfig;
+  const { baseURL, url, method, data, params } = requestConfig;
 
   const token: Token = {
     key: $.auth.data?.accessToken as string,
     secret: $.auth.data?.accessSecret as string,
   };
 
+  const searchParams = new URLSearchParams(params);
+  const stringifiedParams = searchParams.toString();
+  let fullUrl = `${baseURL}${url}`;
+
+  // append the search params
+  if (stringifiedParams) {
+    fullUrl = `${fullUrl}?${stringifiedParams}`;
+  }
+
   const requestData: RequestDataType = {
-    url: `${requestConfig.baseURL}${url}`,
+    url: fullUrl,
     method,
   };
 

--- a/packages/docs/pages/apps/twitter/actions.md
+++ b/packages/docs/pages/apps/twitter/actions.md
@@ -3,6 +3,9 @@ favicon: /favicons/twitter.svg
 items:
   - name: Create Tweet
     desc: Create a tweet.
+items:
+  - name: Search User
+    desc: Search a user.
 ---
 
 <script setup>


### PR DESCRIPTION
To provide an extended step output for the search action, I had to add query strings in the corresponding request. However, our logic of oauth1.0-a signing the request wasn't covering the GET requests with query strings. I have extended its capability in this direction. Since it's a significant change, I have tested the following cases;

- creating a Twitter connection as well as reconnecting an existing one
- testing a connection
- create tweet action
- search user action (thanks to the changes from this branch)
- user tweets trigger
- search tweets trigger
- my tweets trigger
- new follower of me trigger

All these are working without any regressions.