### PR TITLE
fix: Expose error stack together with error message

### DIFF
--- a/packages/backend/src/helpers/error-handler.ts
+++ b/packages/backend/src/helpers/error-handler.ts
@@ -4,11 +4,16 @@ import logger from './logger';
 import BaseError from '../errors/base';
 
 // Do not remove `next` argument as the function signature will not fit for an error handler middleware
-const errorHandler = (err: BaseError, req: Request, res: Response, next: NextFunction): void => {
+const errorHandler = (
+  err: BaseError,
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void => {
   if (err.message === 'Not Found') {
     res.status(404).end();
   } else {
-    logger.error(err.message);
+    logger.error(err.message + '\n' + err.stack);
     res.status(err.statusCode || 500).send(err.message);
   }
 };


### PR DESCRIPTION
Not solving it but related to https://github.com/automatisch/automatisch/issues/1009

Instead of exposing just the error message for the error handler, we will also expose the error stack.

cc: @pareeohnos