### PR TITLE
fix: Expose worker errors with stack trace

### DIFF
--- a/packages/backend/src/workers/action.ts
+++ b/packages/backend/src/workers/action.ts
@@ -23,9 +23,8 @@ const DEFAULT_DELAY_DURATION = 0;
 export const worker = new Worker(
   'action',
   async (job) => {
-    const { stepId, flowId, executionId, computedParameters, executionStep } = await processAction(
-      job.data as JobData
-    );
+    const { stepId, flowId, executionId, computedParameters, executionStep } =
+      await processAction(job.data as JobData);
 
     const step = await Step.query().findById(stepId).throwIfNotFound();
     const nextStep = await step.getNextStep();
@@ -64,14 +63,17 @@ worker.on('completed', (job) => {
 });
 
 worker.on('failed', (job, err) => {
-  logger.info(
-    `JOB ID: ${job.id} - FLOW ID: ${job.data.flowId} has failed to start with ${err.message}`
-  );
+  const errorMessage = `
+    JOB ID: ${job.id} - FLOW ID: ${job.data.flowId} has failed to start with ${err.message}
+    \n ${err.stack}
+  `;
+
+  logger.error(errorMessage);
 
   Sentry.captureException(err, {
     extra: {
       jobId: job.id,
-    }
+    },
   });
 });
 

--- a/packages/backend/src/workers/email.ts
+++ b/packages/backend/src/workers/email.ts
@@ -29,14 +29,17 @@ worker.on('completed', (job) => {
 });
 
 worker.on('failed', (job, err) => {
-  logger.info(
-    `JOB ID: ${job.id} - ${job.data.subject} email to ${job.data.email} has failed to send with ${err.message}`
-  );
+  const errorMessage = `
+    JOB ID: ${job.id} - ${job.data.subject} email to ${job.data.email} has failed to send with ${err.message}
+    \n ${err.stack}
+  `;
+
+  logger.error(errorMessage);
 
   Sentry.captureException(err, {
     extra: {
       jobId: job.id,
-    }
+    },
   });
 });
 

--- a/packages/backend/src/workers/flow.ts
+++ b/packages/backend/src/workers/flow.ts
@@ -6,7 +6,10 @@ import logger from '../helpers/logger';
 import triggerQueue from '../queues/trigger';
 import { processFlow } from '../services/flow';
 import Flow from '../models/flow';
-import { REMOVE_AFTER_30_DAYS_OR_150_JOBS, REMOVE_AFTER_7_DAYS_OR_50_JOBS } from '../helpers/remove-job-configuration';
+import {
+  REMOVE_AFTER_30_DAYS_OR_150_JOBS,
+  REMOVE_AFTER_7_DAYS_OR_50_JOBS,
+} from '../helpers/remove-job-configuration';
 
 export const worker = new Worker(
   'flow',
@@ -30,7 +33,7 @@ export const worker = new Worker(
     const jobOptions = {
       removeOnComplete: REMOVE_AFTER_7_DAYS_OR_50_JOBS,
       removeOnFail: REMOVE_AFTER_30_DAYS_OR_150_JOBS,
-    }
+    };
 
     for (const triggerItem of reversedData) {
       const jobName = `${triggerStep.id}-${triggerItem.meta.internalId}`;
@@ -64,14 +67,17 @@ worker.on('completed', (job) => {
 });
 
 worker.on('failed', (job, err) => {
-  logger.info(
-    `JOB ID: ${job.id} - FLOW ID: ${job.data.flowId} has failed to start with ${err.message}`
-  );
+  const errorMessage = `
+    JOB ID: ${job.id} - FLOW ID: ${job.data.flowId} has failed to start with ${err.message}
+    \n ${err.stack}
+  `;
+
+  logger.error(errorMessage);
 
   Sentry.captureException(err, {
     extra: {
       jobId: job.id,
-    }
+    },
   });
 });
 

--- a/packages/backend/src/workers/trigger.ts
+++ b/packages/backend/src/workers/trigger.ts
@@ -7,7 +7,10 @@ import logger from '../helpers/logger';
 import actionQueue from '../queues/action';
 import Step from '../models/step';
 import { processTrigger } from '../services/trigger';
-import { REMOVE_AFTER_30_DAYS_OR_150_JOBS, REMOVE_AFTER_7_DAYS_OR_50_JOBS } from '../helpers/remove-job-configuration';
+import {
+  REMOVE_AFTER_30_DAYS_OR_150_JOBS,
+  REMOVE_AFTER_7_DAYS_OR_50_JOBS,
+} from '../helpers/remove-job-configuration';
 
 type JobData = {
   flowId: string;
@@ -38,7 +41,7 @@ export const worker = new Worker(
     const jobOptions = {
       removeOnComplete: REMOVE_AFTER_7_DAYS_OR_50_JOBS,
       removeOnFail: REMOVE_AFTER_30_DAYS_OR_150_JOBS,
-    }
+    };
 
     await actionQueue.add(jobName, jobPayload, jobOptions);
   },
@@ -50,14 +53,17 @@ worker.on('completed', (job) => {
 });
 
 worker.on('failed', (job, err) => {
-  logger.info(
-    `JOB ID: ${job.id} - FLOW ID: ${job.data.flowId} has failed to start with ${err.message}`
-  );
+  const errorMessage = `
+    JOB ID: ${job.id} - FLOW ID: ${job.data.flowId} has failed to start with ${err.message}
+    \n ${err.stack}
+  `;
+
+  logger.error(errorMessage);
 
   Sentry.captureException(err, {
     extra: {
       jobId: job.id,
-    }
+    },
   });
 });
 


### PR DESCRIPTION
Fixes #1009

- With this PR, we used error level instead of info to make the difference more evident while checking the logs.
- It's implemented for all workers.