### PR TITLE
fix: stop checking auth urls

### DIFF
--- a/packages/backend/src/graphql/mutations/generate-auth-url.ts
+++ b/packages/backend/src/graphql/mutations/generate-auth-url.ts
@@ -1,8 +1,6 @@
 import Context from '../../types/express/context';
-import axios from 'axios';
 import globalVariable from '../../helpers/global-variable';
 import App from '../../models/app';
-import GenerateAuthUrlError from '../../errors/generate-auth-url';
 
 type Params = {
   input: {
@@ -31,12 +29,7 @@ const generateAuthUrl = async (
   const app = await App.findOneByKey(connection.key);
 
   const $ = await globalVariable({ connection, app });
-  try {
-    await authInstance.generateAuthUrl($);
-    await axios.get(connection.formattedData.url as string);
-  } catch (error) {
-    throw new GenerateAuthUrlError(error);
-  }
+  await authInstance.generateAuthUrl($);
 
   return connection.formattedData;
 };


### PR DESCRIPTION
resolves scenarios like where we receive 403, but it's actually a Cloudflare security check which the user can pass through on the browser.