### PR TITLE
fix(discord): show announcement channels in selection

### DIFF
--- a/packages/backend/src/apps/discord/dynamic-data/list-channels/index.ts
+++ b/packages/backend/src/apps/discord/dynamic-data/list-channels/index.ts
@@ -19,8 +19,8 @@ export default {
 
     channels.data = response.data
       .filter((channel: IJSONObject) => {
-        // filter in text channels only
-        return channel.type === 0;
+        // filter in text channels and announcement channels only
+        return channel.type === 0 || channel.type === 5;
       })
       .map((channel: IJSONObject) => {
         return {


### PR DESCRIPTION
Announcement channels have a separate [channel type](https://discord.com/developers/docs/resources/channel#channel-object-channel-types) from text channels even though they're essentially the same. This fix makes them show in the channel selection as they should.