### PR TITLE
fix(postgresql): close connections when done

### DIFF
--- a/packages/backend/src/apps/postgresql/actions/delete/index.ts
+++ b/packages/backend/src/apps/postgresql/actions/delete/index.ts
@@ -102,6 +102,8 @@ export default defineAction({
       })
       .del() as IJSONArray;
 
+    client.destroy();
+
     $.setActionItem({
       raw: {
         rows: response

--- a/packages/backend/src/apps/postgresql/actions/insert/index.ts
+++ b/packages/backend/src/apps/postgresql/actions/insert/index.ts
@@ -88,6 +88,8 @@ export default defineAction({
       .returning('*')
       .insert(data) as IJSONObject;
 
+    client.destroy();
+
     $.setActionItem({ raw: response[0] as IJSONObject });
   },
 });

--- a/packages/backend/src/apps/postgresql/actions/sql-query/index.ts
+++ b/packages/backend/src/apps/postgresql/actions/sql-query/index.ts
@@ -46,6 +46,7 @@ export default defineAction({
 
     const queryStatemnt = $.step.parameters.queryStatement;
     const { rows } = await client.raw(queryStatemnt);
+    client.destroy();
 
     $.setActionItem({
       raw: {

--- a/packages/backend/src/apps/postgresql/actions/update/index.ts
+++ b/packages/backend/src/apps/postgresql/actions/update/index.ts
@@ -132,6 +132,8 @@ export default defineAction({
       })
       .update(data) as IJSONArray;
 
+    client.destroy();
+
     $.setActionItem({
       raw: {
         rows: response

--- a/packages/backend/src/apps/postgresql/auth/verify-credentials.ts
+++ b/packages/backend/src/apps/postgresql/auth/verify-credentials.ts
@@ -5,6 +5,7 @@ import getClient from '../common/postgres-client';
 const verifyCredentials = async ($: IGlobalVariable) => {
   const client = getClient($);
   const checkConnection = await client.raw('SELECT 1');
+  client.destroy();
 
   logger.debug(checkConnection);
 


### PR DESCRIPTION
Previously db connections were never closed causing a "too many clients already" error to eventually occur, making the database unusable.
This just closes each connection once they're done so that doesn't happen.