### PR TITLE
update the git clone command and fixes the docker command

### DIFF
--- a/packages/docs/pages/guide/installation.md
+++ b/packages/docs/pages/guide/installation.md
@@ -18,13 +18,13 @@ Please be careful with the `ENCRYPTION_KEY` and `WEBHOOK_SECRET_KEY` environment
 
 ```bash
 # Clone the repository
-git clone git@github.com:automatisch/automatisch.git
+git clone https://github.com/automatisch/automatisch.git
 
 # Go to the repository folder
 cd automatisch
 
 # Start
-docker compose up
+docker-compose up
 ```
 
 ✌️ That's it; you have Automatisch running. Let's check it out by browsing [http://localhost:3000](https://localhost:3000)


### PR DESCRIPTION
Fixed the docker and git clone command. It's not always a good option to use ssh as a cloning method and for that I change it to a normal https clone. I hope it might be good for developers. Here it is: 

BEFORE -->
# Clone the repository
git clone git@github.com:automatisch/automatisch.git

# Go to the repository folder
cd automatisch

# Start
docker compose up



AFTER -->
# Clone the repository
git clone https://github.com/automatisch/automatisch.git

# Go to the repository folder
cd automatisch

# Start
docker-compose up