### PR TITLE
fix: use default role for fallback user creation

### DIFF
--- a/packages/backend/src/graphql/mutations/create-user.ee.ts
+++ b/packages/backend/src/graphql/mutations/create-user.ee.ts
@@ -36,7 +36,7 @@ const createUser = async (_parent: unknown, params: Params, context: Context) =>
     userPayload.roleId = params.input.role.id;
   } catch {
     // void
-    const role = await Role.query().findOne({ key: 'user' });
+    const role = await Role.query().findOne({ key: 'admin' });
     userPayload.roleId = role.id;
   }
 


### PR DESCRIPTION
In an unlicensed installation, the user creation fails as the logic tries to use a non-existing `user` role. The changes here aim to use the default admin role we know exists.