### PR TITLE
fix: remove unnecessery styling causing the problem with scrolling Edit/Create role pages

### DIFF
--- a/packages/web/src/components/PermissionCatalogField/PermissionSettings.ee.jsx
+++ b/packages/web/src/components/PermissionCatalogField/PermissionSettings.ee.jsx
@@ -48,9 +48,8 @@ export default function PermissionSettings(props) {
   };
   return (
     <Dialog
-      open
+      open={open}
       onClose={cancel}
-      sx={{ display: open ? 'block' : 'none' }}
       data-test={`${subject}-role-conditions-modal`}
     >
       <DialogTitle>{formatMessage('permissionSettings.title')}</DialogTitle>


### PR DESCRIPTION
[AUT-606](https://linear.app/automatisch/issue/AUT-606/createedit-role-pages-are-not-scrollable-on-small-viewports)

[Link to video](https://www.loom.com/share/21e49603a7de4de1aec17c847a0e37e8?sid=b5287fa1-efa4-43fe-bef1-9e78917e94e8)