### PR TITLE
fix: add optional chaining to data.getTrialStatus check

### DIFF
--- a/packages/web/src/hooks/useTrialStatus.ee.js
+++ b/packages/web/src/hooks/useTrialStatus.ee.js
@@ -59,7 +59,7 @@ export default function useTrialStatus() {
     },
     [checkoutCompleted, hasTrial, stopPolling],
   );
-  if (loading || !data.getTrialStatus) return null;
+  if (loading || !data?.getTrialStatus) return null;
   const expireAt = DateTime.fromMillis(
     Number(data.getTrialStatus.expireAt),
   ).startOf('day');


### PR DESCRIPTION
[AUT-619](https://linear.app/automatisch/issue/AUT-619/page-crashes-after-refreshing-and-letting-the-backend-server-stop)

[Link to the video](https://www.loom.com/share/820d10e60e4a440d82dd961b3e586165?sid=3d91ddb5-9326-434a-aae9-1cb25d8993ec) - there are errors after closing the backend but web app doesn't crash.