### PR TITLE
feat(config): add ability to override apiUrl in environment variables

### DIFF
--- a/packages/backend/src/config/app.js
+++ b/packages/backend/src/config/app.js
@@ -18,7 +18,7 @@ const port = process.env.PORT || '3000';
 const serveWebAppSeparately =
   process.env.SERVE_WEB_APP_SEPARATELY === 'true' ? true : false;
 
-let apiUrl = new URL(process.env.API_URL ? process.env.API_URL: `${protocol}://${host}:${port}`).toString();
+let apiUrl = new URL(process.env.API_URL || `${protocol}://${host}:${port}`).toString();
 apiUrl = apiUrl.substring(0, apiUrl.length - 1);
 
 // use apiUrl by default, which has less priority over the following cases

--- a/packages/backend/src/config/app.js
+++ b/packages/backend/src/config/app.js
@@ -18,10 +18,7 @@ const port = process.env.PORT || '3000';
 const serveWebAppSeparately =
   process.env.SERVE_WEB_APP_SEPARATELY === 'true' ? true : false;
 
-let apiUrl = new URL(`${protocol}://${host}:${port}`).toString();
-if (process.env.API_URL) {
-  apiUrl = process.env.API_URL;
-}
+let apiUrl = new URL(process.env.API_URL ? process.env.API_URL: `${protocol}://${host}:${port}`).toString();
 apiUrl = apiUrl.substring(0, apiUrl.length - 1);
 
 // use apiUrl by default, which has less priority over the following cases

--- a/packages/backend/src/config/app.js
+++ b/packages/backend/src/config/app.js
@@ -19,6 +19,9 @@ const serveWebAppSeparately =
   process.env.SERVE_WEB_APP_SEPARATELY === 'true' ? true : false;
 
 let apiUrl = new URL(`${protocol}://${host}:${port}`).toString();
+if (process.env.API_URL) {
+  apiUrl = process.env.API_URL;
+}
 apiUrl = apiUrl.substring(0, apiUrl.length - 1);
 
 // use apiUrl by default, which has less priority over the following cases


### PR DESCRIPTION
We need the ability to override apiUrl in config. SVG images are not loading when hosted with GAE with a domain eg. 

HOST: www.xyz.com
PROTOCOL: https
PORT: 8080

With the above environment, the apiUrl and baseUrl would be https://www.xyz.com:8080. There is currently no way to remove the port from the baseUrl. This pull request allows you to set the API_URL as an environment variable. If not set, the previous behavior is maintained. 