### PR TITLE
feat(gitlab): Add several GitLab actions

### DIFF
--- a/packages/backend/src/apps/gitlab/actions/create-issue/index.js
+++ b/packages/backend/src/apps/gitlab/actions/create-issue/index.js
@@ -1,0 +1,149 @@
+import defineAction from '../../../../helpers/define-action.js';
+
+export default defineAction({
+  name: 'Create new Issue',
+  key: 'createIssue',
+  description: 'Creates a new project issue.',
+  arguments: [
+    {
+      label: 'Project ID',
+      key: 'id',
+      type: 'string',
+      required: true,
+      description:
+        'The global ID or URL-encoded path of the project owned by the authenticated user.',
+      variables: true,
+    },
+    {
+      label: 'Title',
+      key: 'title',
+      type: 'string',
+      required: true,
+      description: 'The title of an issue.',
+      variables: true,
+    },
+    {
+      label: 'Description',
+      key: 'description',
+      type: 'string',
+      required: false,
+      description:
+        'The description of an issue. Limited to 1,048,576 characters.',
+      variables: true,
+    },
+    {
+      label: 'Assignee ID',
+      key: 'assignee_id',
+      type: 'string',
+      required: false,
+      description:
+        'The ID of the user to assign the issue to. Only appears on GitLab Free.',
+      variables: true,
+    },
+    {
+      label: 'Confidential',
+      key: 'confidential',
+      type: 'dropdown',
+      required: false,
+      description: `Set an issue to be confidential. Default is not confidential.`,
+      value: 'false',
+      options: [
+        { label: 'Not Confidential', value: 'false' },
+        { label: 'Confidential', value: 'true' },
+      ],
+    },
+    {
+      label: 'ID of a discussion to resolve',
+      key: 'discussion_to_resolve',
+      type: 'string',
+      required: false,
+      description:
+        'The ID of a discussion to resolve. This fills out the issue with a default description and mark the discussion as resolved. Use in combination with `merge_request_to_resolve_discussions_of`.',
+      variables: true,
+    },
+    {
+      label: 'Due Date',
+      key: 'due_date',
+      type: 'string',
+      required: false,
+      description:
+        'The due date. Date time string in the format `YYYY-MM-DD`, for example `2016-03-11`.',
+      variables: true,
+    },
+    {
+      label: 'Epic ID',
+      key: 'epic_id',
+      type: 'string',
+      required: false,
+      description:
+        'ID of the epic to add the issue to. Valid values are greater than or equal to 0. Premium and Ultimate only.',
+      variables: true,
+    },
+    {
+      label: 'Issue Type',
+      key: 'type',
+      type: 'dropdown',
+      required: false,
+      description: 'The type of issue.',
+      value: 'issue',
+      options: [
+        { label: 'Issue', value: 'issue' },
+        { label: 'Incident', value: 'incident' },
+        { label: 'Test Case', value: 'test_case' },
+        { label: 'Task', value: 'task' },
+      ],
+    },
+    {
+      label: 'Labels',
+      key: 'labels',
+      type: 'string',
+      required: false,
+      description: 'Comma-separated label names for an issue.',
+      variables: true,
+    },
+    {
+      label: 'MR to Resolve Discussions Of',
+      key: 'merge_request_to_resolve_discussions_of',
+      type: 'string',
+      required: false,
+      description:
+        'The IID of a merge request in which to resolve all issues. This fills out the issue with a default description and mark all discussions as resolved. When passing a description or title, these values take precedence over the default values.',
+      variables: true,
+    },
+    {
+      label: 'Milestone ID',
+      key: 'milestone_id',
+      type: 'string',
+      required: false,
+      description:
+        "The global ID of a milestone to assign issue. To find the milestone_id associated with a milestone, view an issue with the milestone assigned and use the API to retrieve the issue's details.",
+      variables: true,
+    },
+    {
+      label: 'Weight',
+      key: 'weight',
+      type: 'string',
+      required: false,
+      description:
+        'The weight of the issue. Valid values are greater than or equal to 0. Premium and Ultimate only.',
+      variables: true,
+    },
+  ],
+
+  async run($) {
+    const { id, title, ...params } = $.step.parameters;
+    if (!id) throw new Error('A project must be set!');
+    if (!title) throw new Error('A title must be set!');
+
+    const response = await $.http.post(
+      `/api/v4/projects/${encodeURI(id)}/issues`,
+      {
+        id,
+        title,
+        ...params,
+      }
+    );
+
+    $.setActionItem({ raw: response.data });
+  },
+});

--- a/packages/backend/src/apps/gitlab/actions/index.js
+++ b/packages/backend/src/apps/gitlab/actions/index.js
@@ -1,7 +1,16 @@
-import createIssue from './create-issue/index.js';
+import issueCreate from './issues/create.js';
+import issueUpdate from './issues/update.js';
+import issueList from './issues/list.js';
 
 import issueLinkCreate from './issue-links/create.js';
 import issueLinkDelete from './issue-links/delete.js';
 import issueLinkList from './issue-links/list.js';
 
-export default [createIssue, issueLinkList, issueLinkCreate, issueLinkDelete];
+export default [
+  issueCreate,
+  issueLinkCreate,
+  issueLinkDelete,
+  issueLinkList,
+  issueList,
+  issueUpdate,
+];

--- a/packages/backend/src/apps/gitlab/actions/index.js
+++ b/packages/backend/src/apps/gitlab/actions/index.js
@@ -1,10 +1,10 @@
 import issueCreate from './issues/create.js';
 import issueUpdate from './issues/update.js';
 import issueList from './issues/list.js';
-
 import issueLinkCreate from './issue-links/create.js';
 import issueLinkDelete from './issue-links/delete.js';
 import issueLinkList from './issue-links/list.js';
+import notes from './notes/index.js';
 
 export default [
   issueCreate,
@@ -13,4 +13,5 @@ export default [
   issueLinkList,
   issueList,
   issueUpdate,
+  ...notes,
 ];

--- a/packages/backend/src/apps/gitlab/actions/index.js
+++ b/packages/backend/src/apps/gitlab/actions/index.js
@@ -1,3 +1,7 @@
-import createIssue from "./create-issue/index.js";
+import createIssue from './create-issue/index.js';
 
-export default [createIssue];
+import issueLinkCreate from './issue-links/create.js';
+import issueLinkDelete from './issue-links/delete.js';
+import issueLinkList from './issue-links/list.js';
+
+export default [createIssue, issueLinkList, issueLinkCreate, issueLinkDelete];

--- a/packages/backend/src/apps/gitlab/actions/index.js
+++ b/packages/backend/src/apps/gitlab/actions/index.js
@@ -1,6 +1,7 @@
 import issueCreate from './issues/create.js';
 import issueUpdate from './issues/update.js';
 import issueList from './issues/list.js';
+import issueGet from './issues/get.js';
 import issueLinkCreate from './issue-links/create.js';
 import issueLinkDelete from './issue-links/delete.js';
 import issueLinkList from './issue-links/list.js';
@@ -8,6 +9,7 @@ import notes from './notes/index.js';
 
 export default [
   issueCreate,
+  issueGet,
   issueLinkCreate,
   issueLinkDelete,
   issueLinkList,

--- a/packages/backend/src/apps/gitlab/actions/index.js
+++ b/packages/backend/src/apps/gitlab/actions/index.js
@@ -1,19 +1,5 @@
-import issueCreate from './issues/create.js';
-import issueUpdate from './issues/update.js';
-import issueList from './issues/list.js';
-import issueGet from './issues/get.js';
-import issueLinkCreate from './issue-links/create.js';
-import issueLinkDelete from './issue-links/delete.js';
-import issueLinkList from './issue-links/list.js';
+import issues from './issues/index.js';
+import issueLinks from './issue-links/index.js';
 import notes from './notes/index.js';
 
-export default [
-  issueCreate,
-  issueGet,
-  issueLinkCreate,
-  issueLinkDelete,
-  issueLinkList,
-  issueList,
-  issueUpdate,
-  ...notes,
-];
+export default [...issues, ...issueLinks, ...notes];

--- a/packages/backend/src/apps/gitlab/actions/index.js
+++ b/packages/backend/src/apps/gitlab/actions/index.js
@@ -1,0 +1,3 @@
+import createIssue from "./create-issue/index.js";
+
+export default [createIssue];

--- a/packages/backend/src/apps/gitlab/actions/issue-links/create.js
+++ b/packages/backend/src/apps/gitlab/actions/issue-links/create.js
@@ -1,7 +1,7 @@
 import defineAction from '../../../../helpers/define-action.js';
 
 export default defineAction({
-  name: 'Issue: Create an new Issue Relation',
+  name: 'Issue: Create a new Issue Relation',
   key: 'issueLinkCreate',
   description:
     'Creates a two-way relation between two issues. The user must be allowed to update both issues to succeed.',

--- a/packages/backend/src/apps/gitlab/actions/issue-links/create.js
+++ b/packages/backend/src/apps/gitlab/actions/issue-links/create.js
@@ -1,0 +1,71 @@
+import defineAction from '../../../../helpers/define-action.js';
+
+export default defineAction({
+  name: 'Create an new Issue Relation',
+  key: 'issueLinkCreate',
+  description:
+    'Creates a two-way relation between two issues. The user must be allowed to update both issues to succeed.',
+  arguments: [
+    {
+      label: 'Project ID',
+      key: 'id',
+      type: 'string',
+      required: true,
+      description:
+        'The global ID or URL-encoded path of the project owned by the authenticated user.',
+      variables: true,
+    },
+    {
+      label: 'Issue Internal ID',
+      key: 'issue_iid',
+      type: 'string',
+      required: true,
+      description: "The internal ID of a project's issue",
+      variables: true,
+    },
+    {
+      label: 'Link Type',
+      key: 'link_type',
+      type: 'dropdown',
+      required: true,
+      description:
+        'The type of the relation (`relates_to`, `blocks`, `is_blocked_by`), defaults to `relates_to`',
+      value: 'relates_to',
+      options: [
+        { label: 'Relates to', value: 'relates_to' },
+        { label: 'Blocks', value: 'blocks' },
+        { label: 'Is Blocked By', value: 'is_blocked_by' },
+      ],
+    },
+    {
+      label: 'Target Project ID',
+      key: 'target_project_id',
+      type: 'string',
+      required: true,
+      description:
+        'The ID or URL-encoded path of the project of a target project',
+      variables: true,
+    },
+    {
+      label: 'Target Issue Internal ID',
+      key: 'target_issue_iid',
+      type: 'string',
+      required: true,
+      description: "The internal ID of a target project's issue",
+      variables: true,
+    },
+  ],
+
+  async run($) {
+    const { id, issue_iid, ...params } = $.step.parameters;
+
+    const response = await $.http.post(
+      `/api/v4/projects/${id}/issues/${issue_iid}/links`,
+      {
+        ...params,
+      }
+    );
+
+    $.setActionItem({ raw: response.data });
+  },
+});

--- a/packages/backend/src/apps/gitlab/actions/issue-links/create.js
+++ b/packages/backend/src/apps/gitlab/actions/issue-links/create.js
@@ -1,7 +1,7 @@
 import defineAction from '../../../../helpers/define-action.js';
 
 export default defineAction({
-  name: 'Create an new Issue Relation',
+  name: 'Issue: Create an new Issue Relation',
   key: 'issueLinkCreate',
   description:
     'Creates a two-way relation between two issues. The user must be allowed to update both issues to succeed.',

--- a/packages/backend/src/apps/gitlab/actions/issue-links/create.js
+++ b/packages/backend/src/apps/gitlab/actions/issue-links/create.js
@@ -62,7 +62,7 @@ export default defineAction({
     const response = await $.http.post(
       `/api/v4/projects/${id}/issues/${issue_iid}/links`,
       {
-        ...params,
+        params,
       }
     );
 

--- a/packages/backend/src/apps/gitlab/actions/issue-links/create.js
+++ b/packages/backend/src/apps/gitlab/actions/issue-links/create.js
@@ -11,8 +11,7 @@ export default defineAction({
       key: 'id',
       type: 'string',
       required: true,
-      description:
-        'The global ID or URL-encoded path of the project owned by the authenticated user.',
+      description: 'The global ID or path of the project.',
       variables: true,
     },
     {

--- a/packages/backend/src/apps/gitlab/actions/issue-links/delete.js
+++ b/packages/backend/src/apps/gitlab/actions/issue-links/delete.js
@@ -52,7 +52,7 @@ export default defineAction({
     const response = await $.http.delete(
       `/api/v4/projects/${id}/issues/${issue_iid}/links/${issue_link_id}`,
       {
-        ...params,
+        params,
       }
     );
 

--- a/packages/backend/src/apps/gitlab/actions/issue-links/delete.js
+++ b/packages/backend/src/apps/gitlab/actions/issue-links/delete.js
@@ -1,7 +1,7 @@
 import defineAction from '../../../../helpers/define-action.js';
 
 export default defineAction({
-  name: 'Delete an Issue Relation',
+  name: 'Issue: Delete an Issue Relation',
   key: 'issueLinksDelete',
   description: 'Deletes an issue link, thus removes the two-way relationship.',
   arguments: [

--- a/packages/backend/src/apps/gitlab/actions/issue-links/delete.js
+++ b/packages/backend/src/apps/gitlab/actions/issue-links/delete.js
@@ -1,0 +1,61 @@
+import defineAction from '../../../../helpers/define-action.js';
+
+export default defineAction({
+  name: 'Delete an Issue Relation',
+  key: 'issueLinksDelete',
+  description: 'Deletes an issue link, thus removes the two-way relationship.',
+  arguments: [
+    {
+      label: 'Project ID',
+      key: 'id',
+      type: 'string',
+      required: true,
+      description:
+        'The global ID or URL-encoded path of the project owned by the authenticated user.',
+      variables: true,
+    },
+    {
+      label: 'Issue Internal ID',
+      key: 'issue_iid',
+      type: 'string',
+      required: true,
+      description: "The internal ID of a project's issue",
+      variables: true,
+    },
+    {
+      label: 'Issue Link ID',
+      key: 'issue_link_id',
+      type: 'string',
+      required: true,
+      description: 'The ID of an issue relationship',
+      variables: true,
+    },
+    {
+      label: 'Link Type',
+      key: 'link_type',
+      type: 'dropdown',
+      required: false,
+      description:
+        'The type of the relation (relates_to, blocks, is_blocked_by), defaults to relates_to',
+      value: 'relates_to',
+      options: [
+        { label: 'Relates to', value: 'relates_to' },
+        { label: 'Blocks', value: 'blocks' },
+        { label: 'Is Blocked By', value: 'is_blocked_by' },
+      ],
+    },
+  ],
+
+  async run($) {
+    const { id, issue_iid, issue_link_id, ...params } = $.step.parameters;
+
+    const response = await $.http.delete(
+      `/api/v4/projects/${id}/issues/${issue_iid}/links/${issue_link_id}`,
+      {
+        ...params,
+      }
+    );
+
+    $.setActionItem({ raw: response.data });
+  },
+});

--- a/packages/backend/src/apps/gitlab/actions/issue-links/delete.js
+++ b/packages/backend/src/apps/gitlab/actions/issue-links/delete.js
@@ -10,8 +10,7 @@ export default defineAction({
       key: 'id',
       type: 'string',
       required: true,
-      description:
-        'The global ID or URL-encoded path of the project owned by the authenticated user.',
+      description: 'The global ID or path of the project.',
       variables: true,
     },
     {

--- a/packages/backend/src/apps/gitlab/actions/issue-links/index.js
+++ b/packages/backend/src/apps/gitlab/actions/issue-links/index.js
@@ -1,0 +1,5 @@
+import linkCreate from './create.js';
+import linkDelete from './delete.js';
+import linkList from './list.js';
+
+export default [linkCreate, linkDelete, linkList];

--- a/packages/backend/src/apps/gitlab/actions/issue-links/list.js
+++ b/packages/backend/src/apps/gitlab/actions/issue-links/list.js
@@ -1,7 +1,7 @@
 import defineAction from '../../../../helpers/define-action.js';
 
 export default defineAction({
-  name: 'List Issue Relations',
+  name: 'Issue: List Issue Relations',
   key: 'issueLinksList',
   description:
     "Get a list of a given issue's linked issues, sorted by the relationship creation datetime (ascending). Issues are filtered according to the user authorizations.",

--- a/packages/backend/src/apps/gitlab/actions/issue-links/list.js
+++ b/packages/backend/src/apps/gitlab/actions/issue-links/list.js
@@ -1,0 +1,37 @@
+import defineAction from '../../../../helpers/define-action.js';
+
+export default defineAction({
+  name: 'List Issue Relations',
+  key: 'issueLinksList',
+  description:
+    "Get a list of a given issue's linked issues, sorted by the relationship creation datetime (ascending). Issues are filtered according to the user authorizations.",
+  arguments: [
+    {
+      label: 'Project ID',
+      key: 'id',
+      type: 'string',
+      required: true,
+      description:
+        'The global ID or URL-encoded path of the project owned by the authenticated user.',
+      variables: true,
+    },
+    {
+      label: 'Issue Internal ID',
+      key: 'issue_iid',
+      type: 'string',
+      required: true,
+      description: "The internal ID of a project's issue",
+      variables: true,
+    },
+  ],
+
+  async run($) {
+    const { id, issue_iid } = $.step.parameters;
+
+    const response = await $.http.get(
+      `/api/v4/projects/${id}/issues/${issue_iid}/links`
+    );
+
+    $.setActionItem({ raw: response.data });
+  },
+});

--- a/packages/backend/src/apps/gitlab/actions/issue-links/list.js
+++ b/packages/backend/src/apps/gitlab/actions/issue-links/list.js
@@ -11,8 +11,7 @@ export default defineAction({
       key: 'id',
       type: 'string',
       required: true,
-      description:
-        'The global ID or URL-encoded path of the project owned by the authenticated user.',
+      description: 'The global ID or path of the project.',
       variables: true,
     },
     {

--- a/packages/backend/src/apps/gitlab/actions/issues/create.js
+++ b/packages/backend/src/apps/gitlab/actions/issues/create.js
@@ -2,7 +2,7 @@ import defineAction from '../../../../helpers/define-action.js';
 
 export default defineAction({
   name: 'Create new Issue',
-  key: 'createIssue',
+  key: 'issueCreate',
   description: 'Creates a new project issue.',
   arguments: [
     {
@@ -131,16 +131,12 @@ export default defineAction({
   ],
 
   async run($) {
-    const { id, title, ...params } = $.step.parameters;
-    if (!id) throw new Error('A project must be set!');
-    if (!title) throw new Error('A title must be set!');
+    const { id, ...params } = $.step.parameters;
 
     const response = await $.http.post(
       `/api/v4/projects/${encodeURI(id)}/issues`,
       {
-        id,
-        title,
-        ...params,
+        params,
       }
     );
 

--- a/packages/backend/src/apps/gitlab/actions/issues/create.js
+++ b/packages/backend/src/apps/gitlab/actions/issues/create.js
@@ -66,7 +66,7 @@ export default defineAction({
       type: 'string',
       required: false,
       description:
-        'The due date. Date time string in the format `YYYY-MM-DD`, for example `2016-03-11`.',
+        'The due date. Date time string in the format `YYYY-MM-DD`, for example `2011-10-03`.',
       variables: true,
     },
     {

--- a/packages/backend/src/apps/gitlab/actions/issues/create.js
+++ b/packages/backend/src/apps/gitlab/actions/issues/create.js
@@ -1,7 +1,7 @@
 import defineAction from '../../../../helpers/define-action.js';
 
 export default defineAction({
-  name: 'Create new Issue',
+  name: 'Issue: Create new Issue',
   key: 'issueCreate',
   description: 'Creates a new project issue.',
   arguments: [

--- a/packages/backend/src/apps/gitlab/actions/issues/create.js
+++ b/packages/backend/src/apps/gitlab/actions/issues/create.js
@@ -10,8 +10,7 @@ export default defineAction({
       key: 'id',
       type: 'string',
       required: true,
-      description:
-        'The global ID or URL-encoded path of the project owned by the authenticated user.',
+      description: 'The global ID or path of the project.',
       variables: true,
     },
     {

--- a/packages/backend/src/apps/gitlab/actions/issues/create.js
+++ b/packages/backend/src/apps/gitlab/actions/issues/create.js
@@ -1,7 +1,7 @@
 import defineAction from '../../../../helpers/define-action.js';
 
 export default defineAction({
-  name: 'Issue: Create new Issue',
+  name: 'Issue: Create a new project Issue',
   key: 'issueCreate',
   description: 'Creates a new project issue.',
   arguments: [

--- a/packages/backend/src/apps/gitlab/actions/issues/delete.js
+++ b/packages/backend/src/apps/gitlab/actions/issues/delete.js
@@ -1,0 +1,36 @@
+import defineAction from '../../../../helpers/define-action.js';
+
+export default defineAction({
+  name: 'Delete an Issue',
+  key: 'issueDelete',
+  description: 'Deletes an issue. Only for administrators and project owners.',
+  arguments: [
+    {
+      label: 'Project ID',
+      key: 'id',
+      type: 'string',
+      required: true,
+      description:
+        'The global ID or URL-encoded path of the project owned by the authenticated user.',
+      variables: true,
+    },
+    {
+      label: 'Issue Internal ID',
+      key: 'issue_iid',
+      type: 'string',
+      required: true,
+      description: "The internal ID of a project's issue.",
+      variables: true,
+    },
+  ],
+
+  async run($) {
+    const { id, issue_iid } = $.step.parameters;
+
+    const response = await $.http.delete(
+      `/api/v4/projects/${encodeURI(id)}/issues/${issue_iid}`
+    );
+
+    $.setActionItem({ raw: response.data });
+  },
+});

--- a/packages/backend/src/apps/gitlab/actions/issues/delete.js
+++ b/packages/backend/src/apps/gitlab/actions/issues/delete.js
@@ -1,7 +1,7 @@
 import defineAction from '../../../../helpers/define-action.js';
 
 export default defineAction({
-  name: 'Issue: Delete an Issue',
+  name: 'Issue: Delete a project Issue',
   key: 'issueDelete',
   description: 'Deletes an issue. Only for administrators and project owners.',
   arguments: [

--- a/packages/backend/src/apps/gitlab/actions/issues/delete.js
+++ b/packages/backend/src/apps/gitlab/actions/issues/delete.js
@@ -1,7 +1,7 @@
 import defineAction from '../../../../helpers/define-action.js';
 
 export default defineAction({
-  name: 'Delete an Issue',
+  name: 'Issue: Delete an Issue',
   key: 'issueDelete',
   description: 'Deletes an issue. Only for administrators and project owners.',
   arguments: [

--- a/packages/backend/src/apps/gitlab/actions/issues/delete.js
+++ b/packages/backend/src/apps/gitlab/actions/issues/delete.js
@@ -10,8 +10,7 @@ export default defineAction({
       key: 'id',
       type: 'string',
       required: true,
-      description:
-        'The global ID or URL-encoded path of the project owned by the authenticated user.',
+      description: 'The global ID or path of the project.',
       variables: true,
     },
     {

--- a/packages/backend/src/apps/gitlab/actions/issues/get.js
+++ b/packages/backend/src/apps/gitlab/actions/issues/get.js
@@ -1,0 +1,36 @@
+import defineAction from '../../../../helpers/define-action.js';
+
+export default defineAction({
+  name: 'Get Single Project Issue',
+  key: 'singleProjectIssueGet',
+  description: 'Get a single project issue.',
+  arguments: [
+    {
+      label: 'Project ID',
+      key: 'id',
+      type: 'string',
+      required: true,
+      description:
+        'The global ID or URL-encoded path of the project owned by the authenticated user.',
+      variables: true,
+    },
+    {
+      label: 'Issue IID',
+      key: 'issue_iid',
+      type: 'integer',
+      required: true,
+      description: "The internal ID of a project's issue.",
+      variables: true,
+    },
+  ],
+
+  async run($) {
+    const { id, issue_iid } = $.step.parameters;
+
+    const response = await $.http.get(
+      `/api/v4/projects/${encodeURI(id)}/issues/${issue_iid}`
+    );
+
+    $.setActionItem({ raw: response.data });
+  },
+});

--- a/packages/backend/src/apps/gitlab/actions/issues/get.js
+++ b/packages/backend/src/apps/gitlab/actions/issues/get.js
@@ -1,7 +1,7 @@
 import defineAction from '../../../../helpers/define-action.js';
 
 export default defineAction({
-  name: 'Issue: Get Single Project Issue',
+  name: 'Issue: Get single project Issue',
   key: 'singleProjectIssueGet',
   description: 'Get a single project issue.',
   arguments: [

--- a/packages/backend/src/apps/gitlab/actions/issues/get.js
+++ b/packages/backend/src/apps/gitlab/actions/issues/get.js
@@ -1,7 +1,7 @@
 import defineAction from '../../../../helpers/define-action.js';
 
 export default defineAction({
-  name: 'Get Single Project Issue',
+  name: 'Issue: Get Single Project Issue',
   key: 'singleProjectIssueGet',
   description: 'Get a single project issue.',
   arguments: [

--- a/packages/backend/src/apps/gitlab/actions/issues/get.js
+++ b/packages/backend/src/apps/gitlab/actions/issues/get.js
@@ -10,8 +10,7 @@ export default defineAction({
       key: 'id',
       type: 'string',
       required: true,
-      description:
-        'The global ID or URL-encoded path of the project owned by the authenticated user.',
+      description: 'The global ID or path of the project.',
       variables: true,
     },
     {

--- a/packages/backend/src/apps/gitlab/actions/issues/index.js
+++ b/packages/backend/src/apps/gitlab/actions/issues/index.js
@@ -1,0 +1,7 @@
+import issueCreate from './create.js';
+import issueDelete from './delete.js';
+import issueGet from './get.js';
+import issueList from './list.js';
+import issueUpdate from './update.js';
+
+export default [issueCreate, issueDelete, issueGet, issueList, issueUpdate];

--- a/packages/backend/src/apps/gitlab/actions/issues/list.js
+++ b/packages/backend/src/apps/gitlab/actions/issues/list.js
@@ -3,7 +3,7 @@ import paginateAll from '../../common/paginate-all.js';
 import { cleanOptionalFields } from '../lib.js';
 
 export default defineAction({
-  name: 'List/Find Project Issues',
+  name: 'Issue: List/Find Project Issues',
   key: 'issueList',
   description: 'Creates a new project issue.',
   arguments: [

--- a/packages/backend/src/apps/gitlab/actions/issues/list.js
+++ b/packages/backend/src/apps/gitlab/actions/issues/list.js
@@ -5,7 +5,7 @@ import { cleanOptionalFields } from '../lib.js';
 export default defineAction({
   name: 'Issue: List/find project Issues',
   key: 'issueList',
-  description: 'Creates a new project issue.',
+  description: 'List or find project issues.',
   arguments: [
     {
       label: 'Project ID',

--- a/packages/backend/src/apps/gitlab/actions/issues/list.js
+++ b/packages/backend/src/apps/gitlab/actions/issues/list.js
@@ -1,0 +1,314 @@
+import defineAction from '../../../../helpers/define-action.js';
+import paginateAll from '../../common/paginate-all.js';
+import { cleanOptionalFields } from '../lib.js';
+
+export default defineAction({
+  name: 'List/Find Project Issues',
+  key: 'issueList',
+  description: 'Creates a new project issue.',
+  arguments: [
+    {
+      label: 'Project ID',
+      key: 'id',
+      type: 'string',
+      required: true,
+      description:
+        'The global ID or URL-encoded path of the project owned by the authenticated user.',
+      variables: true,
+    },
+    {
+      label: 'Search',
+      key: 'search',
+      type: 'string',
+      required: false,
+      description: 'Search project issues against their title and description.',
+      variables: true,
+    },
+    {
+      label: 'Issue Numbers',
+      key: 'iids',
+      type: 'string',
+      required: false,
+      description: 'Comma-separated issue number.',
+      variables: true,
+    },
+    {
+      label: 'Assignee ID',
+      key: 'assignee_id',
+      type: 'string',
+      required: false,
+      description:
+        'Return issues assigned to the given user `id`. Mutually exclusive with `assignee_username`. `None` returns unassigned issues. `Any` returns issues with an assignee.',
+      variables: true,
+    },
+    {
+      label: 'Assignee Username',
+      key: 'assignee_username',
+      type: 'string',
+      required: false,
+      description:
+        'Comma-separated usernames that the issues assigned to. Similar to `assignee_id` and mutually exclusive with `assignee_id`. In GitLab CE, the `assignee_username` array should only contain a single value. Otherwise, an invalid parameter error is returned.',
+      variables: true,
+    },
+    {
+      label: 'Author ID',
+      key: 'author_id',
+      type: 'string',
+      required: false,
+      description:
+        'Return issues created by the given user id. Mutually exclusive with author_username. Combine with scope=all or scope=assigned_to_me.',
+      variables: true,
+    },
+    {
+      label: 'Author Username',
+      key: 'author_username',
+      type: 'string',
+      required: false,
+      description:
+        'Return issues created by the given username. Similar to `author_id` and mutually exclusive with `author_id`.',
+      variables: true,
+    },
+    {
+      label: 'Confidential',
+      key: 'confidential',
+      type: 'dropdown',
+      required: false,
+      description: `Filter confidential or public issues.`,
+      value: '',
+      options: [
+        { label: 'Any', value: '' },
+        { label: 'Not Confidential', value: 'false' },
+        { label: 'Confidential', value: 'true' },
+      ],
+    },
+    {
+      label: 'State',
+      key: 'state',
+      type: 'dropdown',
+      required: false,
+      description: 'Return all issues or just those that are opened or closed.',
+      value: '',
+      options: [
+        { label: 'All', value: '' },
+        { label: 'Opened', value: 'opened' },
+        { label: 'Closed', value: 'closed' },
+      ],
+    },
+    {
+      label: 'Created After',
+      key: 'created_after',
+      type: 'string',
+      required: false,
+      description:
+        'Return issues created on or after the given time. Expected in ISO 8601 format (`2011-11-03T09:00:00Z`).',
+      variables: true,
+    },
+    {
+      label: 'Created After',
+      key: 'created_before',
+      type: 'string',
+      required: false,
+      description:
+        'Return issues created on or before the given time. Expected in ISO 8601 format (`2011-11-03T09:00:00Z`).',
+      variables: true,
+    },
+    {
+      label: 'Due Date',
+      key: 'due_date',
+      type: 'dropdown',
+      required: false,
+      description: `Return issues that have no due date, are overdue, or whose due date is this week, this month, or between two weeks ago and next month.`,
+      value: '0',
+      options: [
+        { label: 'No Due Date', value: '0' },
+        { label: 'Any', value: 'any' },
+        { label: 'Due Today', value: 'today' },
+        { label: 'Due Tommorow', value: 'tomorrow' },
+        { label: 'Overdue', value: 'overdue' },
+        { label: 'Due This Week', value: 'week' },
+        { label: 'Due This Month', value: 'month' },
+        {
+          label: 'Due Between Two Weeks Ago And Next Month',
+          value: 'next_month_and_previous_two_weeks',
+        },
+      ],
+    },
+    {
+      label: 'Epic ID',
+      key: 'epic_id',
+      type: 'string',
+      required: false,
+      description:
+        'Return issues associated with the given epic ID. `None` returns issues that are not associated with an epic. `Any` returns issues that are associated with an epic. Premium and Ultimate only.',
+      variables: true,
+    },
+    {
+      label: 'Issue Type',
+      key: 'issue_type',
+      type: 'dropdown',
+      required: false,
+      description: 'Filter to a given type of issue.',
+      value: '',
+      options: [
+        { label: 'Any', value: '' },
+        { label: 'Issue', value: 'issue' },
+        { label: 'Incident', value: 'incident' },
+        { label: 'Test Case', value: 'test_case' },
+        { label: 'Task', value: 'task' },
+      ],
+    },
+    {
+      label: 'Scope',
+      key: 'scope',
+      type: 'dropdown',
+      required: false,
+      description:
+        'Return issues for the given scope: `created_by_me`, `assigned_to_me` or `all`. Defaults to `all`.',
+      value: 'all',
+      options: [
+        { label: 'All', value: 'all' },
+        { label: 'Created by Me', value: 'created_by_me' },
+        { label: 'Assigned to Me', value: 'assigned_to_me' },
+      ],
+    },
+    {
+      label: 'Labels',
+      key: 'labels',
+      type: 'string',
+      required: false,
+      description:
+        'Comma-separated list of label names, issues must have all labels to be returned. `None` lists all issues with no labels. `Any` lists all issues with at least one label. Predefined names are case-insensitive.',
+    },
+    {
+      label: 'Iteration ID',
+      key: 'iteration_id',
+      type: 'string',
+      required: false,
+      description:
+        'Return issues assigned to the given iteration ID. None returns issues that do not belong to an iteration. Any returns issues that belong to an iteration. Mutually exclusive with iteration_title. Premium and Ultimate only.',
+      variables: true,
+    },
+    {
+      label: 'Iteration Title',
+      key: 'iteration_title',
+      type: 'string',
+      required: false,
+      description:
+        'Return issues assigned to the iteration with the given title. Similar to `iteration_id` and mutually exclusive with `iteration_id`. Premium and Ultimate only.',
+      variables: true,
+    },
+
+    {
+      label: 'Milestone Title',
+      key: 'milestone',
+      type: 'string',
+      required: false,
+      description:
+        'The milestone title. `None` lists all issues with no milestone. `Any` lists all issues that have an assigned milestone.',
+      variables: true,
+    },
+    {
+      label: 'My Reaction',
+      key: 'my_reaction_emoji',
+      type: 'string',
+      required: false,
+      description:
+        'Return issues reacted by the authenticated user by the given emoji. `None` returns issues not given a reaction. `Any` returns issues given at least one reaction.',
+      variables: true,
+    },
+
+    {
+      label: 'Updated After',
+      key: 'updated_after',
+      type: 'string',
+      required: false,
+      description:
+        'Return issues updated on or after the given time. Expected in ISO 8601 format (`2011-11-03T09:00:00Z`).',
+      variables: true,
+    },
+    {
+      label: 'Updated After',
+      key: 'updated_before',
+      type: 'string',
+      required: false,
+      description:
+        'Return issues updated on or before the given time. Expected in ISO 8601 format (`2011-11-03T09:00:00Z`).',
+      variables: true,
+    },
+    {
+      label: 'Weight',
+      key: 'weight',
+      type: 'string',
+      required: false,
+      description:
+        'Return issues with the specified weight. `None` returns issues with no weight assigned. `Any` returns issues with a weight assigned. Premium and Ultimate only.',
+      variables: true,
+    },
+    {
+      label: 'Order By',
+      key: 'order_by',
+      type: 'dropdown',
+      required: false,
+      description:
+        'Return issues ordered by `created_at`, `updated_at`, `priority`, `due_date`, `relative_position`, `label_priority`, `milestone_due`, `popularity`, `weight` fields. Default is `created_at`.',
+      value: 'created_at',
+      options: [
+        { label: 'Created Date', value: 'created_at' },
+        { label: 'Updated Date', value: 'updated_at' },
+        { label: 'Priority', value: 'priority' },
+        { label: 'Due Date', value: 'due_date' },
+        { label: 'Relative Position', value: 'relative_position' },
+        { label: 'Label Priority', value: 'label_priority' },
+        { label: 'Milestone Due', value: 'milestone_due' },
+        { label: 'Popularity', value: 'popularity' },
+        { label: 'Weight', value: 'weight' },
+      ],
+    },
+    {
+      label: 'Sort',
+      key: 'sort',
+      type: 'dropdown',
+      required: false,
+      description:
+        'Return issues sorted in `asc` or `desc` order. Default is `desc`.',
+      value: 'desc',
+      options: [
+        { label: 'Ascending', value: 'asc' },
+        { label: 'Descending', value: 'desc' },
+      ],
+    },
+    {
+      label: 'Expand the Label Details',
+      key: 'with_labels_details',
+      type: 'dropdown',
+      required: false,
+      description:
+        'If `true`, the response returns more details for each label in labels field: `:name`, `:color`, `:description`, `:description_html`, `:text_color`. Default is `false`.',
+      value: 'false',
+      options: [
+        { label: "Don't Expand", value: 'false' },
+        { label: 'Expand', value: 'true' },
+      ],
+    },
+  ],
+
+  async run($) {
+    let { id, ...params } = $.step.parameters;
+
+    params = cleanOptionalFields(params);
+
+    if (params.iids) {
+      params.iids = params.iids.split(',').map((iid) => iid.trim());
+    }
+
+    let response = await $.http.get(
+      `/api/v4/projects/${encodeURI(id)}/issues`,
+      {
+        params,
+      }
+    );
+    response = paginateAll($, response);
+
+    $.setActionItem({ raw: response.data });
+  },
+});

--- a/packages/backend/src/apps/gitlab/actions/issues/list.js
+++ b/packages/backend/src/apps/gitlab/actions/issues/list.js
@@ -99,7 +99,7 @@ export default defineAction({
       type: 'string',
       required: false,
       description:
-        'Return issues created on or after the given time. Expected in ISO 8601 format (`2011-11-03T09:00:00Z`).',
+        'Return issues created on or after the given time. Expected in ISO 8601 format (`2011-10-03T05:18:00Z`).',
       variables: true,
     },
     {
@@ -108,7 +108,7 @@ export default defineAction({
       type: 'string',
       required: false,
       description:
-        'Return issues created on or before the given time. Expected in ISO 8601 format (`2011-11-03T09:00:00Z`).',
+        'Return issues created on or before the given time. Expected in ISO 8601 format (`2011-10-03T05:18:00Z`).',
       variables: true,
     },
     {
@@ -222,7 +222,7 @@ export default defineAction({
       type: 'string',
       required: false,
       description:
-        'Return issues updated on or after the given time. Expected in ISO 8601 format (`2011-11-03T09:00:00Z`).',
+        'Return issues updated on or after the given time. Expected in ISO 8601 format (`2011-10-03T05:18:00Z`).',
       variables: true,
     },
     {
@@ -231,7 +231,7 @@ export default defineAction({
       type: 'string',
       required: false,
       description:
-        'Return issues updated on or before the given time. Expected in ISO 8601 format (`2011-11-03T09:00:00Z`).',
+        'Return issues updated on or before the given time. Expected in ISO 8601 format (`2011-10-03T05:18:00Z`).',
       variables: true,
     },
     {

--- a/packages/backend/src/apps/gitlab/actions/issues/list.js
+++ b/packages/backend/src/apps/gitlab/actions/issues/list.js
@@ -12,8 +12,7 @@ export default defineAction({
       key: 'id',
       type: 'string',
       required: true,
-      description:
-        'The global ID or URL-encoded path of the project owned by the authenticated user.',
+      description: 'The global ID or path of the project.',
       variables: true,
     },
     {

--- a/packages/backend/src/apps/gitlab/actions/issues/list.js
+++ b/packages/backend/src/apps/gitlab/actions/issues/list.js
@@ -3,7 +3,7 @@ import paginateAll from '../../common/paginate-all.js';
 import { cleanOptionalFields } from '../lib.js';
 
 export default defineAction({
-  name: 'Issue: List/Find Project Issues',
+  name: 'Issue: List/find project Issues',
   key: 'issueList',
   description: 'Creates a new project issue.',
   arguments: [

--- a/packages/backend/src/apps/gitlab/actions/issues/update.js
+++ b/packages/backend/src/apps/gitlab/actions/issues/update.js
@@ -1,0 +1,198 @@
+import defineAction from '../../../../helpers/define-action.js';
+import { cleanOptionalFields } from '../lib.js';
+
+export default defineAction({
+  name: 'Update an Issue',
+  key: 'issueUpdate',
+  description:
+    'Updates an existing project issue. This request is also used to close or reopen an issue (with state_event).',
+  arguments: [
+    {
+      label: 'Project ID',
+      key: 'id',
+      type: 'string',
+      required: true,
+      description:
+        'The global ID or URL-encoded path of the project owned by the authenticated user.',
+      variables: true,
+    },
+    {
+      label: 'Issue Internal ID',
+      key: 'issue_iid',
+      type: 'string',
+      required: true,
+      description: "The internal ID of a project's issue.",
+      variables: true,
+    },
+    {
+      label: 'Title',
+      key: 'title',
+      type: 'string',
+      required: false,
+      placeholder: '(Unchanged)',
+      description: 'The title of an issue.',
+      variables: true,
+    },
+    {
+      label: 'Add Labels',
+      key: 'add_labels',
+      type: 'string',
+      required: false,
+      description: 'Comma-separated label names to add to an issue.',
+      variables: true,
+    },
+    {
+      label: 'Remove Labels',
+      key: 'remove_labels',
+      type: 'string',
+      required: false,
+      description: 'Comma-separated label names to remove from an issue.',
+      variables: true,
+    },
+    {
+      label: 'Labels',
+      key: 'labels',
+      type: 'string',
+      required: false,
+      description:
+        'Comma-separated label names for an issue. Leave it empty to not set the label, set to `0` to remove all labels.',
+      variables: true,
+    },
+    {
+      label: 'Assignee IDs',
+      key: 'assignee_ids',
+      type: 'string',
+      required: false,
+      description:
+        'Comma-separated IDs of the users to assign the issue to. Set to `0` or provide an empty value to unassign all assignees.',
+      variables: true,
+    },
+    {
+      label: 'Confidential',
+      key: 'confidential',
+      type: 'dropdown',
+      required: false,
+      description: `Set an issue to be confidential. Default is not confidential.`,
+      value: '',
+      options: [
+        { label: "Don't Change", value: '' },
+        { label: 'Not Confidential', value: 'false' },
+        { label: 'Confidential', value: 'true' },
+      ],
+    },
+    {
+      label: 'Description',
+      key: 'description',
+      type: 'string',
+      required: false,
+      description:
+        'The description of an issue. Limited to 1,048,576 characters.',
+      variables: true,
+    },
+    {
+      label: 'Lock Discussion',
+      key: 'discussion_locked',
+      type: 'dropdown',
+      required: false,
+      description: `Flag indicating if the issue's discussion is locked. If the discussion is locked only project members can add or edit comments.`,
+      value: '',
+      options: [
+        { label: "Don't Change", value: '' },
+        { label: 'Unlocked', value: 'false' },
+        { label: 'Locked', value: 'true' },
+      ],
+    },
+    {
+      label: 'Due Date',
+      key: 'due_date',
+      type: 'string',
+      required: false,
+      description:
+        'The due date. Date time string in the format `YYYY-MM-DD`, for example `2016-03-11`.',
+      variables: true,
+    },
+    {
+      label: 'Epic ID',
+      key: 'epic_id',
+      type: 'string',
+      required: false,
+      description:
+        'ID of the epic to add the issue to. Valid values are greater than or equal to 0. Premium and Ultimate only.',
+      variables: true,
+    },
+    {
+      label: 'Issue Type',
+      key: 'type',
+      type: 'dropdown',
+      required: false,
+      description: 'The type of issue.',
+      value: '',
+      options: [
+        { label: "Don't Change", value: '' },
+        { label: 'Issue', value: 'issue' },
+        { label: 'Incident', value: 'incident' },
+        { label: 'Test Case', value: 'test_case' },
+        { label: 'Task', value: 'task' },
+      ],
+    },
+    {
+      label: 'Milestone ID',
+      key: 'milestone_id',
+      type: 'string',
+      required: false,
+      description:
+        'The global ID of a milestone to assign the issue to. Set to `0` or provide an empty value to unassign a milestone.',
+      variables: true,
+    },
+    {
+      label: 'Issue State',
+      key: 'type',
+      type: 'dropdown',
+      required: false,
+      description:
+        'The state event of an issue. To close the issue, use `close`, and to reopen it, use `reopen`.',
+      value: '',
+      options: [
+        { label: "Don't Change", value: '' },
+        { label: 'Close', value: 'close' },
+        { label: 'Reopen', value: 'reopen' },
+      ],
+    },
+    {
+      label: 'Weight',
+      key: 'weight',
+      type: 'string',
+      required: false,
+      description:
+        'The weight of the issue. Valid values are greater than or equal to 0. Premium and Ultimate only.',
+      variables: true,
+    },
+  ],
+
+  async run($) {
+    let { id, issue_iid, ...params } = $.step.parameters;
+
+    params = cleanOptionalFields(params);
+
+    // Since the `0` part of the label parameter is our convention, not GitLab,
+    // we convert those on the fly.
+    if (params.label === '0') {
+      params.label = [];
+    }
+
+    if (params.assignee_ids) {
+      params.assignee_ids = params.assignee_ids
+        .split(',')
+        .map((id) => id.trim());
+    }
+
+    const response = await $.http.put(
+      `/api/v4/projects/${encodeURI(id)}/issues/${issue_iid}`,
+      {
+        ...params,
+      }
+    );
+
+    $.setActionItem({ raw: response.data });
+  },
+});

--- a/packages/backend/src/apps/gitlab/actions/issues/update.js
+++ b/packages/backend/src/apps/gitlab/actions/issues/update.js
@@ -2,7 +2,7 @@ import defineAction from '../../../../helpers/define-action.js';
 import { cleanOptionalFields } from '../lib.js';
 
 export default defineAction({
-  name: 'Issue: Update an Issue',
+  name: 'Issue: Update a project Issue',
   key: 'issueUpdate',
   description:
     'Updates an existing project issue. This request is also used to close or reopen an issue (with state_event).',

--- a/packages/backend/src/apps/gitlab/actions/issues/update.js
+++ b/packages/backend/src/apps/gitlab/actions/issues/update.js
@@ -2,7 +2,7 @@ import defineAction from '../../../../helpers/define-action.js';
 import { cleanOptionalFields } from '../lib.js';
 
 export default defineAction({
-  name: 'Update an Issue',
+  name: 'Issue: Update an Issue',
   key: 'issueUpdate',
   description:
     'Updates an existing project issue. This request is also used to close or reopen an issue (with state_event).',

--- a/packages/backend/src/apps/gitlab/actions/issues/update.js
+++ b/packages/backend/src/apps/gitlab/actions/issues/update.js
@@ -107,7 +107,7 @@ export default defineAction({
       type: 'string',
       required: false,
       description:
-        'The due date. Date time string in the format `YYYY-MM-DD`, for example `2016-03-11`.',
+        'The due date. Date time string in the format `YYYY-MM-DD`, for example `2011-10-03`.',
       variables: true,
     },
     {

--- a/packages/backend/src/apps/gitlab/actions/issues/update.js
+++ b/packages/backend/src/apps/gitlab/actions/issues/update.js
@@ -12,8 +12,7 @@ export default defineAction({
       key: 'id',
       type: 'string',
       required: true,
-      description:
-        'The global ID or URL-encoded path of the project owned by the authenticated user.',
+      description: 'The global ID or path of the project.',
       variables: true,
     },
     {

--- a/packages/backend/src/apps/gitlab/actions/issues/update.js
+++ b/packages/backend/src/apps/gitlab/actions/issues/update.js
@@ -189,7 +189,7 @@ export default defineAction({
     const response = await $.http.put(
       `/api/v4/projects/${encodeURI(id)}/issues/${issue_iid}`,
       {
-        ...params,
+        params,
       }
     );
 

--- a/packages/backend/src/apps/gitlab/actions/lib.js
+++ b/packages/backend/src/apps/gitlab/actions/lib.js
@@ -1,0 +1,21 @@
+/**
+ * Cleanups the fields that does not have any value set on them.
+ *
+ * @param {Map<string, string>} fields
+ * @return {Map<string, string>} Cleaned fields
+ */
+export function cleanOptionalFields(fields) {
+  const cleanedFields = {};
+  for (const key in fields) {
+    if (
+      fields[key] === '' ||
+      fields[key] === undefined ||
+      fields[key] === null
+    ) {
+      continue;
+    }
+    cleanedFields[key] = fields[key];
+  }
+
+  return cleanedFields;
+}

--- a/packages/backend/src/apps/gitlab/actions/notes/index.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/index.js
@@ -1,0 +1,33 @@
+import issueCreate from './issues/create.js';
+import issueDelete from './issues/delete.js';
+import issueGet from './issues/get.js';
+import issueList from './issues/list.js';
+import issueUpdate from './issues/update.js';
+import snippetsCreate from './snippets/create.js';
+import snippetsDelete from './snippets/delete.js';
+import snippetsGet from './snippets/get.js';
+import snippetsList from './snippets/list.js';
+import snippetsUpdate from './snippets/update.js';
+import mergeRequestCreate from './merge-request/create.js';
+import mergeRequestDelete from './merge-request/delete.js';
+import mergeRequestGet from './merge-request/get.js';
+import mergeRequestList from './merge-request/list.js';
+import mergeRequestUpdate from './merge-request/update.js';
+
+export default [
+  issueCreate,
+  issueDelete,
+  issueGet,
+  issueList,
+  issueUpdate,
+  snippetsCreate,
+  snippetsDelete,
+  snippetsGet,
+  snippetsList,
+  snippetsUpdate,
+  mergeRequestCreate,
+  mergeRequestDelete,
+  mergeRequestGet,
+  mergeRequestList,
+  mergeRequestUpdate,
+];

--- a/packages/backend/src/apps/gitlab/actions/notes/issues/create.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/issues/create.js
@@ -1,0 +1,67 @@
+import defineAction from '../../../../../helpers/define-action.js';
+
+export default defineAction({
+  name: 'Create New Issue Note',
+  key: 'issueNoteCreate',
+  description: 'Creates a new note to a single project issue.',
+  arguments: [
+    {
+      label: 'Project ID',
+      key: 'id',
+      type: 'string',
+      required: true,
+      description: 'The global ID or URL-encoded path of the project.',
+      variables: true,
+    },
+    {
+      label: 'Issue Internal ID',
+      key: 'issue_iid',
+      type: 'integer',
+      required: true,
+      description: "The internal ID of a project's issue.",
+      variables: true,
+    },
+    {
+      label: 'Body',
+      key: 'body',
+      type: 'string',
+      required: true,
+      description: 'The content of a note. Limited to 1,000,000 characters.',
+      variables: true,
+    },
+    {
+      label: 'Internal',
+      key: 'internal',
+      type: 'dropdown',
+      required: false,
+      description: 'The internal flag of a note. Default is `false`.',
+      value: 'false',
+      options: [
+        { label: 'Not Confidential', value: 'false' },
+        { label: 'Confidential', value: 'true' },
+      ],
+    },
+    {
+      label: 'Created At',
+      key: 'created_at',
+      type: 'string',
+      required: false,
+      description:
+        'Date time string, ISO 8601 formatted. It must be after 1970-01-01. Example: `2011-11-03T09:00:00Z` (requires administrator or project/group owner rights)',
+      variables: true,
+    },
+  ],
+
+  async run($) {
+    const { id, issue_iid, ...params } = $.step.parameters;
+
+    const response = await $.http.post(
+      `/api/v4/projects/${encodeURI(id)}/issues/${issue_iid}/notes`,
+      {
+        params,
+      }
+    );
+
+    $.setActionItem({ raw: response.data });
+  },
+});

--- a/packages/backend/src/apps/gitlab/actions/notes/issues/create.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/issues/create.js
@@ -47,7 +47,7 @@ export default defineAction({
       type: 'string',
       required: false,
       description:
-        'Date time string, ISO 8601 formatted. It must be after 1970-01-01. Example: `2011-11-03T09:00:00Z` (requires administrator or project/group owner rights)',
+        'Date time string, ISO 8601 formatted. It must be after 1970-01-01. Example: `2011-10-03T05:18:00Z` (requires administrator or project/group owner rights)',
       variables: true,
     },
   ],

--- a/packages/backend/src/apps/gitlab/actions/notes/issues/create.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/issues/create.js
@@ -1,7 +1,7 @@
 import defineAction from '../../../../../helpers/define-action.js';
 
 export default defineAction({
-  name: 'Create New Issue Note',
+  name: 'Issue: Create New Issue Note',
   key: 'issueNoteCreate',
   description: 'Creates a new note to a single project issue.',
   arguments: [

--- a/packages/backend/src/apps/gitlab/actions/notes/issues/create.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/issues/create.js
@@ -1,7 +1,7 @@
 import defineAction from '../../../../../helpers/define-action.js';
 
 export default defineAction({
-  name: 'Issue: Create New Issue Note',
+  name: 'Issue: Create a new Issue Note',
   key: 'issueNoteCreate',
   description: 'Creates a new note to a single project issue.',
   arguments: [

--- a/packages/backend/src/apps/gitlab/actions/notes/issues/delete.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/issues/delete.js
@@ -1,0 +1,43 @@
+import defineAction from '../../../../../helpers/define-action.js';
+
+export default defineAction({
+  name: 'Delete an Issue Note',
+  key: 'issueNoteDelete',
+  description: 'Deletes an existing note of an issue.',
+  arguments: [
+    {
+      label: 'Project ID',
+      key: 'id',
+      type: 'string',
+      required: true,
+      description: 'The ID or path of the project.',
+      variables: true,
+    },
+    {
+      label: 'Issue Internal ID',
+      key: 'issue_iid',
+      type: 'integer',
+      required: true,
+      description: 'The IID of an issue.',
+      variables: true,
+    },
+    {
+      label: 'Note ID',
+      key: 'note_id',
+      type: 'integer',
+      required: true,
+      description: 'The ID of a note.',
+      variables: true,
+    },
+  ],
+
+  async run($) {
+    const { id, issue_iid, note_id } = $.step.parameters;
+
+    const response = await $.http.delete(
+      `/api/v4/projects/${encodeURI(id)}/issues/${issue_iid}/notes/${note_id}`
+    );
+
+    $.setActionItem({ raw: response.data });
+  },
+});

--- a/packages/backend/src/apps/gitlab/actions/notes/issues/delete.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/issues/delete.js
@@ -1,7 +1,7 @@
 import defineAction from '../../../../../helpers/define-action.js';
 
 export default defineAction({
-  name: 'Delete an Issue Note',
+  name: 'Issue: Delete an Issue Note',
   key: 'issueNoteDelete',
   description: 'Deletes an existing note of an issue.',
   arguments: [

--- a/packages/backend/src/apps/gitlab/actions/notes/issues/get.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/issues/get.js
@@ -1,7 +1,7 @@
 import defineAction from '../../../../../helpers/define-action.js';
 
 export default defineAction({
-  name: 'Issue: Get Single Issue Note',
+  name: 'Issue: Get a single Issue Note',
   key: 'issueNoteGet',
   description: 'Returns a single note for a specific project issue.',
   arguments: [

--- a/packages/backend/src/apps/gitlab/actions/notes/issues/get.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/issues/get.js
@@ -1,0 +1,43 @@
+import defineAction from '../../../../../helpers/define-action.js';
+
+export default defineAction({
+  name: 'Get Single Issue Note',
+  key: 'issueNoteGet',
+  description: 'Returns a single note for a specific project issue.',
+  arguments: [
+    {
+      label: 'Project ID',
+      key: 'id',
+      type: 'string',
+      required: true,
+      description: 'The global ID or URL-encoded path of the project.',
+      variables: true,
+    },
+    {
+      label: 'Issue Internal ID',
+      key: 'issue_iid',
+      type: 'integer',
+      required: true,
+      description: "The internal ID of a project's issue.",
+      variables: true,
+    },
+    {
+      label: 'Note ID',
+      key: 'note_id',
+      type: 'integer',
+      required: true,
+      description: 'The ID of an issue note.',
+      variables: true,
+    },
+  ],
+
+  async run($) {
+    const { id, issue_iid, note_id } = $.step.parameters;
+
+    const response = await $.http.get(
+      `/api/v4/projects/${encodeURI(id)}/issues/${issue_iid}/notes/${note_id}`
+    );
+
+    $.setActionItem({ raw: response.data });
+  },
+});

--- a/packages/backend/src/apps/gitlab/actions/notes/issues/get.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/issues/get.js
@@ -1,7 +1,7 @@
 import defineAction from '../../../../../helpers/define-action.js';
 
 export default defineAction({
-  name: 'Get Single Issue Note',
+  name: 'Issue: Get Single Issue Note',
   key: 'issueNoteGet',
   description: 'Returns a single note for a specific project issue.',
   arguments: [

--- a/packages/backend/src/apps/gitlab/actions/notes/issues/list.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/issues/list.js
@@ -1,0 +1,66 @@
+import defineAction from '../../../../../helpers/define-action.js';
+import paginateAll from '../../../common/paginate-all.js';
+
+export default defineAction({
+  name: 'List Issue Notes',
+  key: 'issueNotesList',
+  description: 'Gets a list of all notes for a single issue.',
+  arguments: [
+    {
+      label: 'Project ID',
+      key: 'id',
+      type: 'string',
+      required: true,
+      description: 'The global ID or URL-encoded path of the project.',
+      variables: true,
+    },
+    {
+      label: 'Issue Internal ID',
+      key: 'issue_iid',
+      type: 'integer',
+      required: true,
+      description: "The internal ID of a project's issue.",
+      variables: true,
+    },
+    {
+      label: 'Sort',
+      key: 'sort',
+      type: 'dropdown',
+      required: false,
+      description:
+        'Return issue notes sorted in `asc` or `desc` order. Default is `desc`.',
+      value: 'desc',
+      options: [
+        { label: 'Ascending', value: 'asc' },
+        { label: 'Descending', value: 'desc' },
+      ],
+    },
+    {
+      label: 'Order By',
+      key: 'order_by',
+      type: 'dropdown',
+      required: false,
+      description:
+        'Return issue notes ordered by `created_at` or `updated_at` fields. Default is `created_at`.',
+      value: 'created_at',
+      options: [
+        { label: 'Created At', value: 'created_at' },
+        { label: 'Updated At', value: 'updated_at' },
+      ],
+    },
+  ],
+
+  async run($) {
+    const { id, issue_iid, ...params } = $.step.parameters;
+
+    let response = await $.http.get(
+      `/api/v4/projects/${encodeURI(id)}/issues/${issue_iid}/notes`,
+      {
+        params,
+      }
+    );
+    response = paginateAll($, response);
+
+    $.setActionItem({ raw: response.data });
+  },
+});

--- a/packages/backend/src/apps/gitlab/actions/notes/issues/list.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/issues/list.js
@@ -2,7 +2,7 @@ import defineAction from '../../../../../helpers/define-action.js';
 import paginateAll from '../../../common/paginate-all.js';
 
 export default defineAction({
-  name: 'List Issue Notes',
+  name: 'Issue: List Issue Notes',
   key: 'issueNotesList',
   description: 'Gets a list of all notes for a single issue.',
   arguments: [

--- a/packages/backend/src/apps/gitlab/actions/notes/issues/update.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/issues/update.js
@@ -1,7 +1,7 @@
 import defineAction from '../../../../../helpers/define-action.js';
 
 export default defineAction({
-  name: 'Update an Issue Note',
+  name: 'Issue: Update an Issue Note',
   key: 'issueNoteUpdate',
   description: 'Modify existing note of an issue.',
   arguments: [

--- a/packages/backend/src/apps/gitlab/actions/notes/issues/update.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/issues/update.js
@@ -1,0 +1,53 @@
+import defineAction from '../../../../../helpers/define-action.js';
+
+export default defineAction({
+  name: 'Update an Issue Note',
+  key: 'issueNoteUpdate',
+  description: 'Modify existing note of an issue.',
+  arguments: [
+    {
+      label: 'Project ID',
+      key: 'id',
+      type: 'string',
+      required: true,
+      description: 'The global ID or URL-encoded path of the project.',
+      variables: true,
+    },
+    {
+      label: 'Issue Internal ID',
+      key: 'issue_iid',
+      type: 'integer',
+      required: true,
+      description: "The internal ID of a project's issue.",
+      variables: true,
+    },
+    {
+      label: 'Note ID',
+      key: 'note_id',
+      type: 'integer',
+      required: true,
+      description: 'The ID of a note.',
+      variables: true,
+    },
+    {
+      label: 'Body',
+      key: 'body',
+      type: 'string',
+      required: false,
+      description: 'The content of a note. Limited to 1,000,000 characters.',
+    },
+  ],
+
+  async run($) {
+    const { id, issue_iid, note_id, ...params } = $.step.parameters;
+
+    const response = await $.http.put(
+      `/api/v4/projects/${encodeURI(id)}/issues/${issue_iid}/notes/${note_id}`,
+      {
+        params,
+      }
+    );
+
+    $.setActionItem({ raw: response.data });
+  },
+});

--- a/packages/backend/src/apps/gitlab/actions/notes/merge-request/create.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/merge-request/create.js
@@ -1,7 +1,7 @@
 import defineAction from '../../../../../helpers/define-action.js';
 
 export default defineAction({
-  name: 'Merge Request: Create New Merge Request Note',
+  name: 'Merge Request: Create a new Merge Request Note',
   key: 'mergeRequestNoteCreate',
   description:
     'Creates a new note for a single merge request. Notes are not attached to specific lines in a merge request.',

--- a/packages/backend/src/apps/gitlab/actions/notes/merge-request/create.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/merge-request/create.js
@@ -36,7 +36,7 @@ export default defineAction({
       type: 'string',
       required: false,
       description:
-        'Date time string, ISO 8601 formatted. Example: `2011-11-03T09:00:00Z` (requires administrator or project/group owner rights).',
+        'Date time string, ISO 8601 formatted. Example: `2011-10-03T05:18:00Z` (requires administrator or project/group owner rights).',
       variables: true,
     },
     {

--- a/packages/backend/src/apps/gitlab/actions/notes/merge-request/create.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/merge-request/create.js
@@ -1,7 +1,7 @@
 import defineAction from '../../../../../helpers/define-action.js';
 
 export default defineAction({
-  name: 'Create New Merge Request Note',
+  name: 'Merge Request: Create New Merge Request Note',
   key: 'mergeRequestNoteCreate',
   description:
     'Creates a new note for a single merge request. Notes are not attached to specific lines in a merge request.',

--- a/packages/backend/src/apps/gitlab/actions/notes/merge-request/create.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/merge-request/create.js
@@ -1,0 +1,65 @@
+import defineAction from '../../../../../helpers/define-action.js';
+
+export default defineAction({
+  name: 'Create New Merge Request Note',
+  key: 'mergeRequestNoteCreate',
+  description:
+    'Creates a new note for a single merge request. Notes are not attached to specific lines in a merge request.',
+  arguments: [
+    {
+      label: 'Project ID',
+      key: 'id',
+      type: 'string',
+      required: true,
+      description: 'The ID or path of the project.',
+      variables: true,
+    },
+    {
+      label: 'Merge Request IID',
+      key: 'merge_request_iid',
+      type: 'integer',
+      required: true,
+      description: 'The IID of a project merge request.',
+      variables: true,
+    },
+    {
+      label: 'Body',
+      key: 'body',
+      type: 'string',
+      required: true,
+      description: 'The content of a note. Limited to 1,000,000 characters.',
+      variables: true,
+    },
+    {
+      label: 'Created At',
+      key: 'created_at',
+      type: 'string',
+      required: false,
+      description:
+        'Date time string, ISO 8601 formatted. Example: `2011-11-03T09:00:00Z` (requires administrator or project/group owner rights).',
+      variables: true,
+    },
+    {
+      label: 'Merge Request Diff Head SHA',
+      key: 'merge_request_diff_head_sha',
+      type: 'string',
+      required: false,
+      description:
+        "Required for the `/merge` quick action. The SHA of the head commit, which ensures the merge request wasn't updated after the API request was sent.",
+      variables: true,
+    },
+  ],
+
+  async run($) {
+    const { id, merge_request_iid, ...params } = $.step.parameters;
+
+    const response = await $.http.post(
+      `/api/v4/projects/${encodeURI(
+        id
+      )}/merge_requests/${merge_request_iid}/notes`,
+      { params }
+    );
+
+    $.setActionItem({ raw: response.data });
+  },
+});

--- a/packages/backend/src/apps/gitlab/actions/notes/merge-request/delete.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/merge-request/delete.js
@@ -1,7 +1,7 @@
 import defineAction from '../../../../../helpers/define-action.js';
 
 export default defineAction({
-  name: 'Merge Request: Delete Merge Request Note',
+  name: 'Merge Request: Delete a Merge Request Note',
   key: 'mergeRequestNoteDelete',
   description: 'Deletes an existing note of a merge request.',
   arguments: [

--- a/packages/backend/src/apps/gitlab/actions/notes/merge-request/delete.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/merge-request/delete.js
@@ -1,7 +1,7 @@
 import defineAction from '../../../../../helpers/define-action.js';
 
 export default defineAction({
-  name: 'Delete Merge Request Note',
+  name: 'Merge Request: Delete Merge Request Note',
   key: 'mergeRequestNoteDelete',
   description: 'Deletes an existing note of a merge request.',
   arguments: [

--- a/packages/backend/src/apps/gitlab/actions/notes/merge-request/delete.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/merge-request/delete.js
@@ -1,0 +1,45 @@
+import defineAction from '../../../../../helpers/define-action.js';
+
+export default defineAction({
+  name: 'Delete Merge Request Note',
+  key: 'mergeRequestNoteDelete',
+  description: 'Deletes an existing note of a merge request.',
+  arguments: [
+    {
+      label: 'Project ID',
+      key: 'id',
+      type: 'string',
+      required: true,
+      description: 'The ID or path of the project.',
+      variables: true,
+    },
+    {
+      label: 'Merge Request IID',
+      key: 'merge_request_iid',
+      type: 'integer',
+      required: true,
+      description: 'The IID of a merge request.',
+      variables: true,
+    },
+    {
+      label: 'Note ID',
+      key: 'note_id',
+      type: 'integer',
+      required: true,
+      description: 'The ID of a note.',
+      variables: true,
+    },
+  ],
+
+  async run($) {
+    const { id, merge_request_iid, note_id } = $.step.parameters;
+
+    const response = await $.http.delete(
+      `/api/v4/projects/${encodeURI(
+        id
+      )}/merge_requests/${merge_request_iid}/notes/${note_id}`
+    );
+
+    $.setActionItem({ raw: response.data });
+  },
+});

--- a/packages/backend/src/apps/gitlab/actions/notes/merge-request/get.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/merge-request/get.js
@@ -1,7 +1,7 @@
 import defineAction from '../../../../../helpers/define-action.js';
 
 export default defineAction({
-  name: 'Merge Request: Get Single Merge Request Note',
+  name: 'Merge Request: Get a single Merge Request Note',
   key: 'mergeRequestNoteGet',
   description: 'Returns a single note for a given merge request.',
   arguments: [

--- a/packages/backend/src/apps/gitlab/actions/notes/merge-request/get.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/merge-request/get.js
@@ -1,7 +1,7 @@
 import defineAction from '../../../../../helpers/define-action.js';
 
 export default defineAction({
-  name: 'Get Single Merge Request Note',
+  name: 'Merge Request: Get Single Merge Request Note',
   key: 'mergeRequestNoteGet',
   description: 'Returns a single note for a given merge request.',
   arguments: [

--- a/packages/backend/src/apps/gitlab/actions/notes/merge-request/get.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/merge-request/get.js
@@ -1,0 +1,45 @@
+import defineAction from '../../../../../helpers/define-action.js';
+
+export default defineAction({
+  name: 'Get Single Merge Request Note',
+  key: 'mergeRequestNoteGet',
+  description: 'Returns a single note for a given merge request.',
+  arguments: [
+    {
+      label: 'Project ID',
+      key: 'id',
+      type: 'string',
+      required: true,
+      description: 'The ID or path of the project.',
+      variables: true,
+    },
+    {
+      label: 'Merge Request IID',
+      key: 'merge_request_iid',
+      type: 'integer',
+      required: true,
+      description: 'The IID of a project merge request.',
+      variables: true,
+    },
+    {
+      label: 'Note ID',
+      key: 'note_id',
+      type: 'integer',
+      required: true,
+      description: 'The ID of a merge request note.',
+      variables: true,
+    },
+  ],
+
+  async run($) {
+    const { id, merge_request_iid, note_id } = $.step.parameters;
+
+    const response = await $.http.get(
+      `/api/v4/projects/${encodeURI(
+        id
+      )}/merge_requests/${merge_request_iid}/notes/${note_id}`
+    );
+
+    $.setActionItem({ raw: response.data });
+  },
+});

--- a/packages/backend/src/apps/gitlab/actions/notes/merge-request/list.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/merge-request/list.js
@@ -2,7 +2,7 @@ import defineAction from '../../../../../helpers/define-action.js';
 import paginateAll from '../../../common/paginate-all.js';
 
 export default defineAction({
-  name: 'List Merge Request Notes',
+  name: 'Merge Request: List Merge Request Notes',
   key: 'mergeRequestNotesList',
   description: 'Gets a list of all notes for a single merge request.',
   arguments: [

--- a/packages/backend/src/apps/gitlab/actions/notes/merge-request/list.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/merge-request/list.js
@@ -1,0 +1,68 @@
+import defineAction from '../../../../../helpers/define-action.js';
+import paginateAll from '../../../common/paginate-all.js';
+
+export default defineAction({
+  name: 'List Merge Request Notes',
+  key: 'mergeRequestNotesList',
+  description: 'Gets a list of all notes for a single merge request.',
+  arguments: [
+    {
+      label: 'Project ID',
+      key: 'id',
+      type: 'string',
+      required: true,
+      description: 'The ID or path of the project.',
+      variables: true,
+    },
+    {
+      label: 'Merge Request IID',
+      key: 'merge_request_iid',
+      type: 'string',
+      required: true,
+      description: 'The IID of a project merge request.',
+      variables: true,
+    },
+    {
+      label: 'Sort',
+      key: 'sort',
+      type: 'dropdown',
+      required: false,
+      description:
+        'Return snippet notes sorted in ascending or descending order.',
+      value: 'desc',
+      options: [
+        { label: 'Ascending', value: 'asc' },
+        { label: 'Descending', value: 'desc' },
+      ],
+    },
+    {
+      label: 'Order By',
+      key: 'order_by',
+      type: 'dropdown',
+      required: false,
+      description:
+        'Return issue notes ordered by `created_at` or `updated_at` fields. Default is `created_at`.',
+      value: 'created_at',
+      options: [
+        { label: 'Created At', value: 'created_at' },
+        { label: 'Updated At', value: 'updated_at' },
+      ],
+    },
+  ],
+
+  async run($) {
+    const { id, merge_request_iid, ...params } = $.step.parameters;
+
+    let response = await $.http.get(
+      `/api/v4/projects/${encodeURI(
+        id
+      )}/merge_requests/${merge_request_iid}/notes`,
+      {
+        params,
+      }
+    );
+    response = paginateAll($, response);
+
+    $.setActionItem({ raw: response.data });
+  },
+});

--- a/packages/backend/src/apps/gitlab/actions/notes/merge-request/update.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/merge-request/update.js
@@ -1,0 +1,56 @@
+import defineAction from '../../../../../helpers/define-action.js';
+
+export default defineAction({
+  name: 'Modify Merge Request Note',
+  key: 'mergeRequestNoteModify',
+  description: 'Modify an existing note of a merge request.',
+  arguments: [
+    {
+      label: 'Project ID',
+      key: 'id',
+      type: 'string',
+      required: true,
+      description: 'The ID or path of the project.',
+      variables: true,
+    },
+    {
+      label: 'Merge Request IID',
+      key: 'merge_request_iid',
+      type: 'integer',
+      required: true,
+      description: 'The IID of a project merge request.',
+      variables: true,
+    },
+    {
+      label: 'Note ID',
+      key: 'note_id',
+      type: 'integer',
+      required: true,
+      description: 'The ID of a merge request note.',
+      variables: true,
+    },
+    {
+      label: 'Body',
+      key: 'body',
+      type: 'string',
+      required: true,
+      description: 'The content of a note. Limited to 1,000,000 characters.',
+      variables: true,
+    },
+  ],
+
+  async run($) {
+    const { id, merge_request_iid, note_id, ...params } = $.step.parameters;
+
+    const response = await $.http.put(
+      `/api/v4/projects/${encodeURI(
+        id
+      )}/merge_requests/${merge_request_iid}/notes/${note_id}`,
+      {
+        params,
+      }
+    );
+
+    $.setActionItem({ raw: response.data });
+  },
+});

--- a/packages/backend/src/apps/gitlab/actions/notes/merge-request/update.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/merge-request/update.js
@@ -1,7 +1,7 @@
 import defineAction from '../../../../../helpers/define-action.js';
 
 export default defineAction({
-  name: 'Merge Request: Modify Merge Request Note',
+  name: 'Merge Request: Modify a Merge Request Note',
   key: 'mergeRequestNoteModify',
   description: 'Modify an existing note of a merge request.',
   arguments: [

--- a/packages/backend/src/apps/gitlab/actions/notes/merge-request/update.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/merge-request/update.js
@@ -1,7 +1,7 @@
 import defineAction from '../../../../../helpers/define-action.js';
 
 export default defineAction({
-  name: 'Modify Merge Request Note',
+  name: 'Merge Request: Modify Merge Request Note',
   key: 'mergeRequestNoteModify',
   description: 'Modify an existing note of a merge request.',
   arguments: [

--- a/packages/backend/src/apps/gitlab/actions/notes/snippets/create.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/snippets/create.js
@@ -1,7 +1,7 @@
 import defineAction from '../../../../../helpers/define-action.js';
 
 export default defineAction({
-  name: 'Snippet: Create New Snippet Note',
+  name: 'Snippet: Create a new Snippet Note',
   key: 'snippetNoteCreate',
   description: 'Creates a new note for a single snippet.',
   arguments: [

--- a/packages/backend/src/apps/gitlab/actions/notes/snippets/create.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/snippets/create.js
@@ -1,0 +1,56 @@
+import defineAction from '../../../../../helpers/define-action.js';
+
+export default defineAction({
+  name: 'Create New Snippet Note',
+  key: 'snippetNoteCreate',
+  description: 'Creates a new note for a single snippet.',
+  arguments: [
+    {
+      label: 'Project ID',
+      key: 'id',
+      type: 'string',
+      required: true,
+      description: 'The ID or path of the project.',
+      variables: true,
+    },
+    {
+      label: 'Snippet ID',
+      key: 'snippet_id',
+      type: 'integer',
+      required: true,
+      description: 'The ID of a snippet.',
+      variables: true,
+    },
+    {
+      label: 'Body',
+      key: 'body',
+      type: 'string',
+      required: true,
+      description: 'The content of the note. Limited to 1,000,000 characters.',
+      variables: true,
+    },
+    {
+      label: 'Created At',
+      key: 'created_at',
+      type: 'string',
+      required: false,
+      description:
+        'Date time string, ISO 8601 formatted. Example: `2011-11-03T09:00:00Z` (requires administrator or project/group owner rights)',
+      variables: true,
+    },
+  ],
+
+  async run($) {
+    const { id, snippet_id, body, created_at } = $.step.parameters;
+
+    const response = await $.http.post(
+      `/api/v4/projects/${encodeURI(id)}/snippets/${snippet_id}/notes`,
+      {
+        body,
+        created_at,
+      }
+    );
+
+    $.setActionItem({ raw: response.data });
+  },
+});

--- a/packages/backend/src/apps/gitlab/actions/notes/snippets/create.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/snippets/create.js
@@ -35,7 +35,7 @@ export default defineAction({
       type: 'string',
       required: false,
       description:
-        'Date time string, ISO 8601 formatted. Example: `2011-11-03T09:00:00Z` (requires administrator or project/group owner rights)',
+        'Date time string, ISO 8601 formatted. Example: `2011-10-03T05:18:00Z` (requires administrator or project/group owner rights)',
       variables: true,
     },
   ],

--- a/packages/backend/src/apps/gitlab/actions/notes/snippets/create.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/snippets/create.js
@@ -1,7 +1,7 @@
 import defineAction from '../../../../../helpers/define-action.js';
 
 export default defineAction({
-  name: 'Create New Snippet Note',
+  name: 'Snippet: Create New Snippet Note',
   key: 'snippetNoteCreate',
   description: 'Creates a new note for a single snippet.',
   arguments: [

--- a/packages/backend/src/apps/gitlab/actions/notes/snippets/delete.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/snippets/delete.js
@@ -1,7 +1,7 @@
 import defineAction from '../../../../../helpers/define-action.js';
 
 export default defineAction({
-  name: 'Snippet: Delete Snippet Note',
+  name: 'Snippet: Delete a Snippet Note',
   key: 'snippetNoteDelete',
   description: 'Deletes an existing note of a snippet.',
   arguments: [

--- a/packages/backend/src/apps/gitlab/actions/notes/snippets/delete.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/snippets/delete.js
@@ -1,7 +1,7 @@
 import defineAction from '../../../../../helpers/define-action.js';
 
 export default defineAction({
-  name: 'Delete Snippet Note',
+  name: 'Snippet: Delete Snippet Note',
   key: 'snippetNoteDelete',
   description: 'Deletes an existing note of a snippet.',
   arguments: [

--- a/packages/backend/src/apps/gitlab/actions/notes/snippets/delete.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/snippets/delete.js
@@ -1,0 +1,45 @@
+import defineAction from '../../../../../helpers/define-action.js';
+
+export default defineAction({
+  name: 'Delete Snippet Note',
+  key: 'snippetNoteDelete',
+  description: 'Deletes an existing note of a snippet.',
+  arguments: [
+    {
+      label: 'Project ID',
+      key: 'id',
+      type: 'string',
+      required: true,
+      description: 'The ID or path of the project.',
+      variables: true,
+    },
+    {
+      label: 'Snippet ID',
+      key: 'snippet_id',
+      type: 'integer',
+      required: true,
+      description: 'The ID of a snippet.',
+      variables: true,
+    },
+    {
+      label: 'Note ID',
+      key: 'note_id',
+      type: 'integer',
+      required: true,
+      description: 'The ID of a note.',
+      variables: true,
+    },
+  ],
+
+  async run($) {
+    const { id, snippet_id, note_id } = $.step.parameters;
+
+    const response = await $.http.delete(
+      `/api/v4/projects/${encodeURI(
+        id
+      )}/snippets/${snippet_id}/notes/${note_id}`
+    );
+
+    $.setActionItem({ raw: response.data });
+  },
+});

--- a/packages/backend/src/apps/gitlab/actions/notes/snippets/get.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/snippets/get.js
@@ -1,7 +1,7 @@
 import defineAction from '../../../../../helpers/define-action.js';
 
 export default defineAction({
-  name: 'Get Single Snippet Note',
+  name: 'Snippet: Get Single Snippet Note',
   key: 'snippetNoteGet',
   description: 'Returns a single note for a given snippet.',
   arguments: [

--- a/packages/backend/src/apps/gitlab/actions/notes/snippets/get.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/snippets/get.js
@@ -1,0 +1,45 @@
+import defineAction from '../../../../../helpers/define-action.js';
+
+export default defineAction({
+  name: 'Get Single Snippet Note',
+  key: 'snippetNoteGet',
+  description: 'Returns a single note for a given snippet.',
+  arguments: [
+    {
+      label: 'Project ID',
+      key: 'id',
+      type: 'string',
+      required: true,
+      description: 'The ID or path of the project.',
+      variables: true,
+    },
+    {
+      label: 'Snippet ID',
+      key: 'snippet_id',
+      type: 'integer',
+      required: true,
+      description: 'The ID of a project snippet.',
+      variables: true,
+    },
+    {
+      label: 'Note ID',
+      key: 'note_id',
+      type: 'integer',
+      required: true,
+      description: 'The ID of a snippet note.',
+      variables: true,
+    },
+  ],
+
+  async run($) {
+    const { id, snippet_id, note_id } = $.step.parameters;
+
+    const response = await $.http.get(
+      `/api/v4/projects/${encodeURI(
+        id
+      )}/snippets/${snippet_id}/notes/${note_id}`
+    );
+
+    $.setActionItem({ raw: response.data });
+  },
+});

--- a/packages/backend/src/apps/gitlab/actions/notes/snippets/get.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/snippets/get.js
@@ -1,7 +1,7 @@
 import defineAction from '../../../../../helpers/define-action.js';
 
 export default defineAction({
-  name: 'Snippet: Get Single Snippet Note',
+  name: 'Snippet: Get a single Snippet Note',
   key: 'snippetNoteGet',
   description: 'Returns a single note for a given snippet.',
   arguments: [

--- a/packages/backend/src/apps/gitlab/actions/notes/snippets/list.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/snippets/list.js
@@ -2,7 +2,7 @@ import defineAction from '../../../../../helpers/define-action.js';
 import paginateAll from '../../../common/paginate-all.js';
 
 export default defineAction({
-  name: 'List Snippet Notes',
+  name: 'Snippet: List Snippet Notes',
   key: 'snippetNotesList',
   description: 'Gets a list of all notes for a single snippet.',
   arguments: [

--- a/packages/backend/src/apps/gitlab/actions/notes/snippets/list.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/snippets/list.js
@@ -1,0 +1,66 @@
+import defineAction from '../../../../../helpers/define-action.js';
+import paginateAll from '../../../common/paginate-all.js';
+
+export default defineAction({
+  name: 'List Snippet Notes',
+  key: 'snippetNotesList',
+  description: 'Gets a list of all notes for a single snippet.',
+  arguments: [
+    {
+      label: 'Project ID',
+      key: 'id',
+      type: 'string',
+      required: true,
+      description: 'The ID or path of the project.',
+      variables: true,
+    },
+    {
+      label: 'Snippet ID',
+      key: 'snippet_id',
+      type: 'integer',
+      required: true,
+      description: 'The ID of a project snippet.',
+      variables: true,
+    },
+    {
+      label: 'Sort',
+      key: 'sort',
+      type: 'dropdown',
+      required: false,
+      description:
+        'Return snippet notes sorted in ascending or descending order.',
+      value: 'desc',
+      options: [
+        { label: 'Ascending', value: 'asc' },
+        { label: 'Descending', value: 'desc' },
+      ],
+    },
+    {
+      label: 'Order By',
+      key: 'order_by',
+      type: 'dropdown',
+      required: false,
+      description:
+        'Return snippet notes ordered by created_at or updated_at fields.',
+      value: 'created_at',
+      options: [
+        { label: 'Created At', value: 'created_at' },
+        { label: 'Updated At', value: 'updated_at' },
+      ],
+    },
+  ],
+
+  async run($) {
+    const { id, snippet_id, ...params } = $.step.parameters;
+
+    let response = await $.http.get(
+      `/api/v4/projects/${encodeURI(id)}/snippets/${snippet_id}/notes`,
+      {
+        params,
+      }
+    );
+    response = paginateAll($, response);
+
+    $.setActionItem({ raw: response.data });
+  },
+});

--- a/packages/backend/src/apps/gitlab/actions/notes/snippets/update.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/snippets/update.js
@@ -1,0 +1,56 @@
+import defineAction from '../../../../../helpers/define-action.js';
+
+export default defineAction({
+  name: 'Modify Snippet Note',
+  key: 'snippetNoteModify',
+  description: 'Modifies an existing note of a snippet.',
+  arguments: [
+    {
+      label: 'Project ID',
+      key: 'id',
+      type: 'string',
+      required: true,
+      description: 'The ID or path of the project.',
+      variables: true,
+    },
+    {
+      label: 'Snippet ID',
+      key: 'snippet_id',
+      type: 'integer',
+      required: true,
+      description: 'The ID of a snippet.',
+      variables: true,
+    },
+    {
+      label: 'Note ID',
+      key: 'note_id',
+      type: 'integer',
+      required: true,
+      description: 'The ID of a snippet note.',
+      variables: true,
+    },
+    {
+      label: 'Body',
+      key: 'body',
+      type: 'string',
+      required: true,
+      description: 'The content of the note. Limited to 1,000,000 characters.',
+      variables: true,
+    },
+  ],
+
+  async run($) {
+    const { id, snippet_id, note_id, ...params } = $.step.parameters;
+
+    const response = await $.http.put(
+      `/api/v4/projects/${encodeURI(
+        id
+      )}/snippets/${snippet_id}/notes/${note_id}`,
+      {
+        params,
+      }
+    );
+
+    $.setActionItem({ raw: response.data });
+  },
+});

--- a/packages/backend/src/apps/gitlab/actions/notes/snippets/update.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/snippets/update.js
@@ -1,7 +1,7 @@
 import defineAction from '../../../../../helpers/define-action.js';
 
 export default defineAction({
-  name: 'Snippet: Modify Snippet Note',
+  name: 'Snippet: Modify a Snippet Note',
   key: 'snippetNoteModify',
   description: 'Modifies an existing note of a snippet.',
   arguments: [

--- a/packages/backend/src/apps/gitlab/actions/notes/snippets/update.js
+++ b/packages/backend/src/apps/gitlab/actions/notes/snippets/update.js
@@ -1,7 +1,7 @@
 import defineAction from '../../../../../helpers/define-action.js';
 
 export default defineAction({
-  name: 'Modify Snippet Note',
+  name: 'Snippet: Modify Snippet Note',
   key: 'snippetNoteModify',
   description: 'Modifies an existing note of a snippet.',
   arguments: [

--- a/packages/backend/src/apps/gitlab/index.js
+++ b/packages/backend/src/apps/gitlab/index.js
@@ -4,6 +4,7 @@ import setBaseUrl from './common/set-base-url.js';
 import auth from './auth/index.js';
 import triggers from './triggers/index.js';
 import dynamicData from './dynamic-data/index.js';
+import actions from './actions/index.js';
 
 export default defineApp({
   name: 'GitLab',
@@ -18,4 +19,5 @@ export default defineApp({
   auth,
   triggers,
   dynamicData,
+  actions
 });

--- a/packages/docs/pages/.vitepress/config.js
+++ b/packages/docs/pages/.vitepress/config.js
@@ -138,6 +138,7 @@ export default defineConfig({
           collapsed: true,
           items: [
             { text: 'Triggers', link: '/apps/gitlab/triggers' },
+            { text: 'Actions', link: '/apps/gitlab/actions' },
             { text: 'Connection', link: '/apps/gitlab/connection' },
           ],
         },

--- a/packages/docs/pages/apps/gitlab/actions.md
+++ b/packages/docs/pages/apps/gitlab/actions.md
@@ -1,0 +1,57 @@
+---
+favicon: /favicons/gitlab.svg
+items:
+  - name: 'Issue: Create a new project Issue'
+    desc: Creates a new project issue.
+  - name: 'Issue: Delete a project Issue'
+    desc: Deletes an issue. Only for administrators and project owners.
+  - name: 'Issue: Get single project Issue'
+    desc: Get a single project issue.
+  - name: 'Issue: List/find project Issues'
+    desc: List or find project issues.
+  - name: 'Issue: Update a project Issue'
+    desc: Updates an existing project issue. This request is also used to close or reopen an issue (with state_event).
+  - name: 'Issue: Create a new Issue Relation'
+    desc: Creates a two-way relation between two issues. The user must be allowed to update both issues to succeed.
+  - name: 'Issue: Delete an Issue Relation'
+    desc: Deletes an issue link, thus removes the two-way relationship.
+  - name: 'Issue: List Issue Relations'
+    desc: Get a list of a given issue's linked issues, sorted by the relationship creation datetime (ascending). Issues are filtered according to the user authorizations.
+  - name: 'Issue: Create a new Issue Note'
+    desc: Creates a new note to a single project issue.
+  - name: 'Issue: Delete an Issue Note'
+    desc: Deletes an existing note of an issue.
+  - name: 'Issue: Get a single Issue Note'
+    desc: Returns a single note for a specific project issue.
+  - name: 'Issue: List Issue Notes'
+    desc: Gets a list of all notes for a single issue.
+  - name: 'Issue: Update an Issue Note'
+    desc: Modify existing note of an issue.
+  - name: 'Merge Request: Create a new Merge Request Note'
+    desc: Creates a new note for a single merge request. Notes are not attached to specific lines in a merge request.
+  - name: 'Merge Request: Delete a Merge Request Note'
+    desc: Deletes an existing note of a merge request.
+  - name: 'Merge Request: Get a single Merge Request Note'
+    desc: Returns a single note for a given merge request.
+  - name: 'Merge Request: List Merge Request Notes'
+    desc: Gets a list of all notes for a single merge request.
+  - name: 'Merge Request: Modify a Merge Request Note'
+    desc: Modify an existing note of a merge request.
+  - name: 'Snippet: Create a new Snippet Note'
+    desc: Creates a new note for a single snippet.
+  - name: 'Snippet: Delete a Snippet Note'
+    desc: Deletes an existing note of a snippet.
+  - name: 'Snippet: Get a single Snippet Note'
+    desc: Returns a single note for a given snippet.
+  - name: 'Snippet: List Snippet Notes'
+    desc: Gets a list of all notes for a single snippet.
+  - name: 'Snippet: Modify a Snippet Note'
+    desc: Modifies an existing note of a snippet.
+
+---
+
+<script setup>
+  import CustomListing from '../../components/CustomListing.vue'
+</script>
+
+<CustomListing />


### PR DESCRIPTION
This PR adds the following actions for GitLab Integration:
- Create, List, Read, Update, and Delete for Issue.
  Incidentally, the `List` part, the API supports for searching. and `Update` part supports close and reopen the issue.
- Create, List, Read, Update, and Delete Notes for Issue, MR, and Snippet.


This PR will resolve #1567.