### PR TITLE
fix(csp): remove illegal characters in directive names

### DIFF
--- a/packages/backend/src/helpers/web-ui-handler.js
+++ b/packages/backend/src/helpers/web-ui-handler.js
@@ -15,7 +15,7 @@ const webUIHandler = async (app) => {
   app.use(express.static(webBuildPath));
 
   app.get('*', (_req, res) => {
-    res.set('Content-Security-Policy', 'frame-ancestors: none;');
+    res.set('Content-Security-Policy', 'frame-ancestors \'self\';');
     res.set('X-Frame-Options', 'DENY');
 
     res.sendFile(indexHtml);


### PR DESCRIPTION
When visiting the login page there is a console error flagging an invalid CSP directive name. 

![image](https://github.com/automatisch/automatisch/assets/61077785/369bbc64-6d91-4269-9104-7ad6ba665366)

This pull request removes the illegal characters in the directive name frame-ancestors and wraps none in single quote removing the console error. 