### PR TITLE
Add RepoCloud One-Click Deployment Option to installation.md

### DIFF
--- a/packages/docs/pages/guide/installation.md
+++ b/packages/docs/pages/guide/installation.md
@@ -104,6 +104,13 @@ We use default values of render plans with the `render.yaml` file, if you want t
 
 :::
 
+## RepoCloud
+
+<a href="https://repocloud.io/details/?app_id=251">
+  <img src="https://d16t0pc4846x52.cloudfront.net/deploy.png" alt="Deploy to RepoCloud">
+</a>
+
+
 ## Production setup
 
 If you need to change any other environment variables for your production setup, let's check out the [environment variables](/advanced/configuration#environment-variables) section of the configuration page.


### PR DESCRIPTION
This pull request introduces the addition of a RepoCloud deployment button to our project's installation guide, enabling users to deploy our application directly through RepoCloud. This update complements our one existing deployment option, offering users a broader range of platforms to choose from.