### PR TITLE
fix: disable retry on mount by default

### DIFF
--- a/packages/web/src/components/QueryClientProvider/index.jsx
+++ b/packages/web/src/components/QueryClientProvider/index.jsx
@@ -4,12 +4,12 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import api from 'helpers/api.js';
-import useAuthentication from 'hooks/useAuthentication.js';
 
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 1000,
+      retryOnMount: false,
       refetchOnWindowFocus: false,
       // provides a convenient default while it should be overridden for other HTTP methods
       queryFn: async ({ queryKey, signal }) => {

--- a/packages/web/src/hooks/useAutomatischConfig.js
+++ b/packages/web/src/hooks/useAutomatischConfig.js
@@ -8,6 +8,7 @@ export default function useAutomatischConfig() {
       const { data } = await api.get(`/v1/automatisch/config`, {
         signal,
       });
+
       return data;
     },
   });


### PR DESCRIPTION
We have endpoints serving 404 when no data is available for the instance or the user. Therefore, we're happy with no `data` from queries. However, before this branch, React Query kept retrying the failed requests on the mount, causing an infinite loop* in a brand-new installation.

I have turned off the `retryOnMount` feature and suggest we use it on purpose whenever we think it may be needed.

\* It can be reproduced on the login page in a brand-new installation. The logic will keep re-fetching the utomatisch config on the mount as there is no config available by default.