### PR TITLE
fix(SsoProviders): hide empty block

### DIFF
--- a/packages/web/src/components/SsoProviders/index.ee.jsx
+++ b/packages/web/src/components/SsoProviders/index.ee.jsx
@@ -13,7 +13,7 @@ function SsoProviders() {
     useSamlAuthProviders();
   const providers = data?.data;
 
-  if (!isSamlAuthProvidersLoading && providers?.length === 0) return null;
+  if (!isSamlAuthProvidersLoading && !providers?.length) return null;
 
   return (
     <>


### PR DESCRIPTION
**Reproduction steps:**

1. Make sure the non-enterprise edition is running
2. Go to /login
3. There will be an empty block right below the login form

**Actual result:**

There is an empty block right below the login form on /login

**Expected result:**

There shouldn't be an empty block right below the login form on /login