### PR TITLE
feat: use try-catch block for updating flow status

### DIFF
--- a/packages/web/src/components/EditorLayout/index.jsx
+++ b/packages/web/src/components/EditorLayout/index.jsx
@@ -59,23 +59,25 @@ export default function EditorLayout() {
 
   const onFlowStatusUpdate = React.useCallback(
     async (active) => {
-      await updateFlowStatus({
-        variables: {
-          input: {
-            id: flowId,
-            active,
+      try {
+        await updateFlowStatus({
+          variables: {
+            input: {
+              id: flowId,
+              active,
+            },
           },
-        },
-        optimisticResponse: {
-          updateFlowStatus: {
-            __typename: 'Flow',
-            id: flowId,
-            active,
+          optimisticResponse: {
+            updateFlowStatus: {
+              __typename: 'Flow',
+              id: flowId,
+              active,
+            },
           },
-        },
-      });
+        });
 
-      await queryClient.invalidateQueries({ queryKey: ['flows', flowId] });
+        await queryClient.invalidateQueries({ queryKey: ['flows', flowId] });
+      } catch (err) {}
     },
     [flowId, queryClient],
   );


### PR DESCRIPTION
[AUT-1070](https://linear.app/automatisch/issue/AUT-1070/console-error-when-trying-to-publish-invalid-flow)

It seems that this error can be safely ignored on the frontend.