### PR TITLE
feat: block access to flow creation for users without permissions

### DIFF
--- a/packages/web/src/components/NoResultFound/index.jsx
+++ b/packages/web/src/components/NoResultFound/index.jsx
@@ -5,8 +5,10 @@ import AddCircleIcon from '@mui/icons-material/AddCircle';
 import CardActionArea from '@mui/material/CardActionArea';
 import Typography from '@mui/material/Typography';
 import { CardContent } from './style';
+
 export default function NoResultFound(props) {
   const { text, to } = props;
+
   const ActionAreaLink = React.useMemo(
     () =>
       React.forwardRef(function InlineLink(linkProps, ref) {
@@ -15,12 +17,12 @@ export default function NoResultFound(props) {
       }),
     [to],
   );
+
   return (
     <Card elevation={0}>
       <CardActionArea component={ActionAreaLink} {...props}>
         <CardContent>
           {!!to && <AddCircleIcon color="primary" />}
-
           <Typography variant="body1">{text}</Typography>
         </CardContent>
       </CardActionArea>

--- a/packages/web/src/pages/Editor/create.jsx
+++ b/packages/web/src/pages/Editor/create.jsx
@@ -7,13 +7,15 @@ import * as URLS from 'config/urls';
 import useFormatMessage from 'hooks/useFormatMessage';
 import { CREATE_FLOW } from 'graphql/mutations/create-flow';
 import Box from '@mui/material/Box';
+
 export default function CreateFlow() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const formatMessage = useFormatMessage();
-  const [createFlow] = useMutation(CREATE_FLOW);
+  const [createFlow, { error }] = useMutation(CREATE_FLOW);
   const appKey = searchParams.get('appKey');
   const connectionId = searchParams.get('connectionId');
+
   React.useEffect(() => {
     async function initiate() {
       const variables = {};
@@ -33,6 +35,11 @@ export default function CreateFlow() {
     }
     initiate();
   }, [createFlow, navigate, appKey, connectionId]);
+
+  if (error) {
+    return null;
+  }
+
   return (
     <Box
       sx={{
@@ -45,7 +52,6 @@ export default function CreateFlow() {
       }}
     >
       <CircularProgress size={16} thickness={7.5} />
-
       <Typography variant="body2">
         {formatMessage('createFlow.creating')}
       </Typography>

--- a/packages/web/src/pages/Flows/index.jsx
+++ b/packages/web/src/pages/Flows/index.jsx
@@ -17,6 +17,7 @@ import Container from 'components/Container';
 import PageTitle from 'components/PageTitle';
 import SearchInput from 'components/SearchInput';
 import useFormatMessage from 'hooks/useFormatMessage';
+import useCurrentUserAbility from 'hooks/useCurrentUserAbility';
 import * as URLS from 'config/urls';
 import useLazyFlows from 'hooks/useLazyFlows';
 
@@ -26,6 +27,7 @@ export default function Flows() {
   const page = parseInt(searchParams.get('page') || '', 10) || 1;
   const [flowName, setFlowName] = React.useState('');
   const [isLoading, setIsLoading] = React.useState(false);
+  const currentUserAbility = useCurrentUserAbility();
 
   const { data, mutate: fetchFlows } = useLazyFlows(
     { flowName, page },
@@ -124,7 +126,9 @@ export default function Flows() {
         {!isLoading && !hasFlows && (
           <NoResultFound
             text={formatMessage('flows.noFlows')}
-            to={URLS.CREATE_FLOW}
+            {...(currentUserAbility.can('create', 'Flow') && {
+              to: URLS.CREATE_FLOW,
+            })}
           />
         )}
         {!isLoading && pageInfo && pageInfo.totalPages > 1 && (


### PR DESCRIPTION
[AUT-1076](https://linear.app/automatisch/issue/AUT-1076/infinite-circular-progress-for-only-update-role-when-trying-to-add)

In Editor/create.jsx null is returned on error to prevent infinite loading status. This page is only accessible through direct link for users without flow creation permissions, so it should be uncommon for them to try to access it. But as an improvement I think a link to /flows page could be added to show something instead of blank page with error snackbar. @barinali let me know if I should add it.