### PR TITLE
fix: set default locale for luxon's  DateTime

### DIFF
--- a/packages/web/src/index.jsx
+++ b/packages/web/src/index.jsx
@@ -1,4 +1,6 @@
 import { createRoot } from 'react-dom/client';
+import { Settings } from 'luxon';
+
 import ThemeProvider from 'components/ThemeProvider';
 import IntlProvider from 'components/IntlProvider';
 import ApolloProvider from 'components/ApolloProvider';
@@ -9,6 +11,9 @@ import QueryClientProvider from 'components/QueryClientProvider';
 import Router from 'components/Router';
 import routes from 'routes';
 import reportWebVitals from './reportWebVitals';
+
+// Sets the default locale to English for all luxon DateTime instances created afterwards.
+Settings.defaultLocale = 'en';
 
 const container = document.getElementById('root');
 const root = createRoot(container);


### PR DESCRIPTION
[AUT-1069](https://linear.app/automatisch/issue/AUT-1069/flowexecutions-time-is-not-english-only)

I noticed the same problem happens in other places like in AppConnectionRow, ExecutionRow or ExecutionHeader, so I set the 'en' locale globally. 