### PR TITLE
feat: limit vertical scroll to a reasonable boundary

### DIFF
--- a/packages/web/src/components/EditorNew/EditorNew.jsx
+++ b/packages/web/src/components/EditorNew/EditorNew.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback, createContext, useRef } from 'react';
+import { useEffect, useCallback, createContext, useRef, useState } from 'react';
 import { useMutation } from '@apollo/client';
 import { useQueryClient } from '@tanstack/react-query';
 import { FlowPropType } from 'propTypes/propTypes';
@@ -45,11 +45,13 @@ const EditorNew = ({ flow }) => {
   const [edges, setEdges, onEdgesChange] = useEdgesState(
     generateInitialEdges(flow),
   );
+  const [containerHeight, setContainerHeight] = useState(null);
 
   useAutoLayout();
-  useScrollBoundaries();
+  useScrollBoundaries(containerHeight);
 
   const createdStepIdRef = useRef(null);
+  const containerRef = useRef(null);
 
   const openNextStep = useCallback(
     (currentStepId) => {
@@ -229,6 +231,22 @@ const EditorNew = ({ flow }) => {
     }
   }, [flow.steps]);
 
+  useEffect(function updateContainerHeightOnResize() {
+    const updateHeight = () => {
+      if (containerRef.current) {
+        setContainerHeight(containerRef.current.clientHeight);
+      }
+    };
+
+    updateHeight();
+
+    window.addEventListener('resize', updateHeight);
+
+    return () => {
+      window.removeEventListener('resize', updateHeight);
+    };
+  }, []);
+
   return (
     <NodesContext.Provider
       value={{
@@ -247,7 +265,7 @@ const EditorNew = ({ flow }) => {
           flowActive: flow.active,
         }}
       >
-        <EditorWrapper direction="column">
+        <EditorWrapper direction="column" ref={containerRef}>
           <ReactFlow
             nodes={nodes}
             edges={edges}

--- a/packages/web/src/components/EditorNew/useScrollBoundaries.js
+++ b/packages/web/src/components/EditorNew/useScrollBoundaries.js
@@ -1,13 +1,33 @@
-import { useEffect } from 'react';
-import { useViewport, useReactFlow } from 'reactflow';
+import { useEffect, useState } from 'react';
+import { useViewport, useReactFlow, useNodes } from 'reactflow';
 
-export const useScrollBoundaries = () => {
+const scrollYMargin = 100;
+
+export const useScrollBoundaries = (containerHeight) => {
   const { setViewport } = useReactFlow();
   const { x, y, zoom } = useViewport();
+  const nodes = useNodes();
+  const [maxYScroll, setMaxYScroll] = useState(null);
 
-  useEffect(() => {
-    if (y > 0) {
-      setViewport({ x, y: 0, zoom });
-    }
-  }, [y]);
+  useEffect(
+    function updateViewportPosition() {
+      if (y > 0) {
+        setViewport({ x, y: 0, zoom });
+      } else if (typeof maxYScroll === 'number' && y < maxYScroll) {
+        setViewport({ x, y: maxYScroll, zoom });
+      }
+    },
+    [y, maxYScroll],
+  );
+
+  useEffect(
+    function updateMaxYScroll() {
+      if (nodes?.length && containerHeight) {
+        const maxY =
+          containerHeight - nodes[nodes.length - 1].y - scrollYMargin;
+        setMaxYScroll(maxY >= 0 ? 0 : maxY);
+      }
+    },
+    [nodes, containerHeight],
+  );
 };


### PR DESCRIPTION
[AUT-1007](https://linear.app/automatisch/issue/AUT-1007/limit-vertical-scroll-to-a-reasonable-boundary)

Since in react-flow scroll happens by `transform: translate` it is tricky to get the scroll back. Therefore I would suggest to use the old version of the flow editor for now (REACT_APP_USE_NEW_FLOW_EDITOR env variable set to false), that looks the same and has the scroll. And when the paths branching is introduce, the editor will need to have zoom and pan as in Zapier (without scroll) and the new editor could be used. Is that all right?

In this PR I only added scroll boundry for scrolling down.