### PR TITLE
fix: in FlowStep wrap in Form component only controlled inputs

### DIFF
--- a/packages/web/src/components/FlowStep/index.jsx
+++ b/packages/web/src/components/FlowStep/index.jsx
@@ -263,42 +263,41 @@ function FlowStep(props) {
         <Content>
           <List>
             <StepExecutionsProvider value={stepWithTestExecutionsData}>
-              <Form
-                defaultValues={step}
-                onSubmit={handleSubmit}
-                resolver={stepValidationSchema}
-              >
-                <ChooseAppAndEventSubstep
-                  expanded={currentSubstep === 0}
-                  substep={{
-                    key: 'chooAppAndEvent',
-                    name: 'Choose app & event',
-                    arguments: [],
-                  }}
-                  onExpand={() => toggleSubstep(0)}
-                  onCollapse={() => toggleSubstep(0)}
-                  onSubmit={expandNextStep}
-                  onChange={handleChange}
-                  step={step}
-                />
+              <ChooseAppAndEventSubstep
+                expanded={currentSubstep === 0}
+                substep={{
+                  key: 'chooAppAndEvent',
+                  name: 'Choose app & event',
+                  arguments: [],
+                }}
+                onExpand={() => toggleSubstep(0)}
+                onCollapse={() => toggleSubstep(0)}
+                onSubmit={expandNextStep}
+                onChange={handleChange}
+                step={step}
+              />
 
-                {actionOrTrigger &&
-                  substeps?.length > 0 &&
-                  substeps.map((substep, index) => (
-                    <React.Fragment key={`${substep?.name}-${index}`}>
-                      {substep.key === 'chooseConnection' && app && (
-                        <ChooseConnectionSubstep
-                          expanded={currentSubstep === index + 1}
-                          substep={substep}
-                          onExpand={() => toggleSubstep(index + 1)}
-                          onCollapse={() => toggleSubstep(index + 1)}
-                          onSubmit={expandNextStep}
-                          onChange={handleChange}
-                          application={app}
-                          step={step}
-                        />
-                      )}
-
+              {actionOrTrigger &&
+                substeps?.length > 0 &&
+                substeps.map((substep, index) => (
+                  <React.Fragment key={`${substep?.name}-${index}`}>
+                    {substep.key === 'chooseConnection' && app && (
+                      <ChooseConnectionSubstep
+                        expanded={currentSubstep === index + 1}
+                        substep={substep}
+                        onExpand={() => toggleSubstep(index + 1)}
+                        onCollapse={() => toggleSubstep(index + 1)}
+                        onSubmit={expandNextStep}
+                        onChange={handleChange}
+                        application={app}
+                        step={step}
+                      />
+                    )}
+                    <Form
+                      defaultValues={step}
+                      onSubmit={handleSubmit}
+                      resolver={stepValidationSchema}
+                    >
                       {substep.key === 'testStep' && (
                         <TestSubstep
                           expanded={currentSubstep === index + 1}
@@ -317,7 +316,6 @@ function FlowStep(props) {
                           flowId={flowId}
                         />
                       )}
-
                       {substep.key &&
                         ['chooseConnection', 'testStep'].includes(
                           substep.key,
@@ -332,9 +330,9 @@ function FlowStep(props) {
                             step={step}
                           />
                         )}
-                    </React.Fragment>
-                  ))}
-              </Form>
+                    </Form>
+                  </React.Fragment>
+                ))}
             </StepExecutionsProvider>
           </List>
         </Content>


### PR DESCRIPTION
[AUT-1065](https://linear.app/automatisch/issue/AUT-1065/undefined-cannot-be-found)

When clicking Enter after typing something in "Choose an app" and not selecting one of the options, onSubmit function of the form was triggered, since this input in the moment of selecting an app is the only input wrapped in form tag. The inputs in ChooseAppAndEventSubstep and ChooseConnectionSubstep are not wrapped in Controller component from react-hook-form therefore they should not trigger handleSubmit of react-hook-form form, they have their own handlers for when the data is submitted when clicking  "Continue". That is why I removed this components from the Form wrapper. 

I didn't add additional prevention for submitting the value in dropdowns without variables, because from my investigation it is not the cause of the problem. Autocomplete MUI input by deafault let's user submit only one of the options. To submit free text freeSolo prop would need to be used. 

I'm not sure why some of the components in the FlowStep are not controlled by react-hook-form. I can add a follow up task to swap them for controlled versions. I didn't want to do it in this fix, because it will require more changes and testing. 