### PR TITLE
fix(github/create-issue): mark repo field as required

### DIFF
--- a/packages/backend/src/apps/github/actions/create-issue/index.js
+++ b/packages/backend/src/apps/github/actions/create-issue/index.js
@@ -10,7 +10,7 @@ export default defineAction({
       label: 'Repo',
       key: 'repo',
       type: 'dropdown',
-      required: false,
+      required: true,
       variables: true,
       source: {
         type: 'query',


### PR DESCRIPTION
resolves [AUT-1089](https://linear.app/automatisch/issue/AUT-1089/github-repo-not-marked-as-required-when-create-issue-action-is-added)