### PR TITLE
fix: limit resetting form on defaultValues change

### DIFF
--- a/packages/web/src/components/Form/index.jsx
+++ b/packages/web/src/components/Form/index.jsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { FormProvider, useForm, useWatch } from 'react-hook-form';
 import PropTypes from 'prop-types';
+import isEqual from 'lodash/isEqual';
 
 const noop = () => null;
 
@@ -23,6 +24,7 @@ function Form(props) {
   });
 
   const form = useWatch({ control: methods.control });
+  const prevDefaultValues = React.useRef(defaultValues);
 
   /**
    * For fields having `dependsOn` fields, we need to re-validate the form.
@@ -32,7 +34,10 @@ function Form(props) {
   }, [methods.trigger, form]);
 
   React.useEffect(() => {
-    methods.reset(defaultValues);
+    if (!isEqual(defaultValues, prevDefaultValues.current)) {
+      prevDefaultValues.current = defaultValues;
+      methods.reset(defaultValues);
+    }
   }, [defaultValues]);
 
   return (


### PR DESCRIPTION
[AUT-1190](https://linear.app/automatisch/issue/AUT-1190/filter-default-fields-disappear-on-active-step-change)

The issue arises from resetting the form in the custom Form component when defaultValues change. Specifically, the DynamicField and FilterConditions compontents set their default field value within a useEffect, but this value gets overwritten by the form reset triggered in the Form component. This happens because, in React, child useEffect hooks are executed before the parent's useEffect.

To preserve the default values of child components, I implemented a limit on the number of resets performed by the Form componen. 