### PR TITLE
feat: allow both number and string values as sampleValue

### DIFF
--- a/packages/web/src/components/PowerInput/SuggestionItem.jsx
+++ b/packages/web/src/components/PowerInput/SuggestionItem.jsx
@@ -40,7 +40,7 @@ SuggestionItem.propTypes = {
   data: PropTypes.arrayOf(
     PropTypes.shape({
       label: PropTypes.string,
-      sampleValue: PropTypes.string,
+      sampleValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     }),
   ).isRequired,
   onSuggestionClick: PropTypes.func.isRequired,

--- a/packages/web/src/components/Slate/Variable.jsx
+++ b/packages/web/src/components/Slate/Variable.jsx
@@ -32,7 +32,8 @@ Variable.propTypes = {
   children: PropTypes.node.isRequired,
   element: PropTypes.shape({
     name: PropTypes.string.isRequired,
-    sampleValue: PropTypes.string.isRequired,
+    sampleValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+      .isRequired,
   }),
   disabled: PropTypes.bool,
 };


### PR DESCRIPTION
[AUT-1097](https://linear.app/automatisch/issue/AUT-1097/invalid-prop-type-when-setting-up-action-ntfy)