### PR TITLE
fix: use correct default values when editing a role

### DIFF
--- a/packages/web/src/components/PermissionCatalogField/PermissionSettings.ee.jsx
+++ b/packages/web/src/components/PermissionCatalogField/PermissionSettings.ee.jsx
@@ -25,7 +25,6 @@ function PermissionSettings(props) {
     subject,
     actions,
     conditions,
-    defaultChecked,
   } = props;
   const formatMessage = useFormatMessage();
   const { getValues, resetField } = useFormContext();
@@ -106,7 +105,6 @@ function PermissionSettings(props) {
                             dataTest={`${
                               condition.key
                             }-${action.key.toLowerCase()}-checkbox`}
-                            defaultValue={defaultChecked}
                             disabled={
                               getValues(
                                 `${fieldPrefix}.${action.key}.value`,
@@ -144,7 +142,6 @@ PermissionSettings.propTypes = {
   fieldPrefix: PropTypes.string.isRequired,
   subject: PropTypes.string.isRequired,
   open: PropTypes.bool,
-  defaultChecked: PropTypes.bool,
   actions: PropTypes.arrayOf(
     PropTypes.shape({
       label: PropTypes.string,

--- a/packages/web/src/components/PermissionCatalogField/index.ee.jsx
+++ b/packages/web/src/components/PermissionCatalogField/index.ee.jsx
@@ -17,11 +17,7 @@ import usePermissionCatalog from 'hooks/usePermissionCatalog.ee';
 import PermissionSettings from './PermissionSettings.ee';
 import PermissionCatalogFieldLoader from './PermissionCatalogFieldLoader';
 
-const PermissionCatalogField = ({
-  name = 'permissions',
-  disabled = false,
-  defaultChecked = false,
-}) => {
+const PermissionCatalogField = ({ name = 'permissions', disabled = false }) => {
   const { data, isLoading: isPermissionCatalogLoading } =
     usePermissionCatalog();
   const permissionCatalog = data?.data;
@@ -100,7 +96,6 @@ const PermissionCatalogField = ({
                     subject={subject.key}
                     actions={permissionCatalog?.actions}
                     conditions={permissionCatalog?.conditions}
-                    defaultChecked={defaultChecked}
                   />
                 </Stack>
               </TableCell>
@@ -114,7 +109,6 @@ const PermissionCatalogField = ({
 PermissionCatalogField.propTypes = {
   name: PropTypes.string,
   disabled: PropTypes.bool,
-  defaultChecked: PropTypes.bool,
 };
 
 export default PermissionCatalogField;

--- a/packages/web/src/helpers/computePermissions.ee.js
+++ b/packages/web/src/helpers/computePermissions.ee.js
@@ -45,3 +45,36 @@ export function getPermissions(computedPermissions) {
     [],
   );
 }
+
+export const getComputedPermissionsDefaultValues = (
+  data,
+  conditionsInitialValues,
+) => {
+  if (!data) return {};
+
+  const conditions = {};
+  data.conditions.forEach((condition) => {
+    conditions[condition.key] =
+      conditionsInitialValues?.[condition.key] || false;
+  });
+
+  const result = {};
+
+  data.subjects.forEach((subject) => {
+    const subjectKey = subject.key;
+    result[subjectKey] = {};
+
+    data.actions.forEach((action) => {
+      const actionKey = action.key;
+
+      if (action.subjects.includes(subjectKey)) {
+        result[subjectKey][actionKey] = {
+          value: false,
+          conditions: { ...conditions },
+        };
+      }
+    });
+  });
+
+  return result;
+};

--- a/packages/web/src/pages/CreateRole/index.ee.jsx
+++ b/packages/web/src/pages/CreateRole/index.ee.jsx
@@ -11,9 +11,13 @@ import Form from 'components/Form';
 import PageTitle from 'components/PageTitle';
 import TextField from 'components/TextField';
 import * as URLS from 'config/urls';
-import { getPermissions } from 'helpers/computePermissions.ee';
+import {
+  getComputedPermissionsDefaultValues,
+  getPermissions,
+} from 'helpers/computePermissions.ee';
 import useFormatMessage from 'hooks/useFormatMessage';
 import useAdminCreateRole from 'hooks/useAdminCreateRole';
+import usePermissionCatalog from 'hooks/usePermissionCatalog.ee';
 
 export default function CreateRole() {
   const navigate = useNavigate();
@@ -21,6 +25,21 @@ export default function CreateRole() {
   const enqueueSnackbar = useEnqueueSnackbar();
   const { mutateAsync: createRole, isPending: isCreateRolePending } =
     useAdminCreateRole();
+  const { data: permissionCatalogData } = usePermissionCatalog();
+
+  const defaultValues = React.useMemo(
+    () => ({
+      name: '',
+      description: '',
+      computedPermissions: getComputedPermissionsDefaultValues(
+        permissionCatalogData?.data,
+        {
+          isCreator: true,
+        },
+      ),
+    }),
+    [permissionCatalogData],
+  );
 
   const handleRoleCreation = async (roleData) => {
     try {
@@ -64,7 +83,7 @@ export default function CreateRole() {
         </Grid>
 
         <Grid item xs={12} justifyContent="flex-end" sx={{ pt: 5 }}>
-          <Form onSubmit={handleRoleCreation}>
+          <Form onSubmit={handleRoleCreation} defaultValues={defaultValues}>
             <Stack direction="column" gap={2}>
               <TextField
                 required={true}
@@ -81,10 +100,7 @@ export default function CreateRole() {
                 data-test="description-input"
               />
 
-              <PermissionCatalogField
-                name="computedPermissions"
-                defaultChecked={true}
-              />
+              <PermissionCatalogField name="computedPermissions" />
 
               <LoadingButton
                 type="submit"


### PR DESCRIPTION
[AUT-1232](https://linear.app/automatisch/issue/AUT-1232/when-creating-new-role-iscreator-permissions-should-be-added-by)

I removed the defaultChecked prop from the PermissionCatalogField because it wasn't functioning correctly. Instead, I implemented a computation of default values based on the permission catalog data.

Additionally, I fixed the defaultValues on the edit role page. Previously, the defaultValues were not synchronized with the actual role permissions, which has now been corrected.