### PR TITLE
feat: check if cancellationEffectiveDateObject is a valid date

### DIFF
--- a/packages/web/src/components/SubscriptionCancelledAlert/index.ee.jsx
+++ b/packages/web/src/components/SubscriptionCancelledAlert/index.ee.jsx
@@ -11,13 +11,16 @@ export default function SubscriptionCancelledAlert() {
   const formatMessage = useFormatMessage();
   const subscription = useSubscription();
   const trial = useUserTrial();
-
-  if (subscription?.data?.status === 'active' || trial.hasTrial)
-    return <React.Fragment />;
-
   const cancellationEffectiveDateObject = DateTime.fromISO(
     subscription?.data?.cancellationEffectiveDate,
   );
+
+  if (
+    subscription?.data?.status === 'active' ||
+    trial.hasTrial ||
+    !cancellationEffectiveDateObject.isValid
+  )
+    return <React.Fragment />;
 
   return (
     <Alert


### PR DESCRIPTION
[AUT-1167](https://linear.app/automatisch/issue/AUT-1167/invalid-datetime-after-free-plan-is-done)