### PR TITLE
fix: variable chip label disappearing

### DIFF
--- a/packages/web/src/components/Slate/Variable.jsx
+++ b/packages/web/src/components/Slate/Variable.jsx
@@ -7,9 +7,9 @@ function Variable({ attributes, children, element, disabled }) {
   const focused = useFocused();
   const label = (
     <>
+      {children}
       <span style={{ fontWeight: 500 }}>{element.name}</span>:{' '}
       <span style={{ fontWeight: 300 }}>{element.sampleValue}</span>
-      {children}
     </>
   );
   return (


### PR DESCRIPTION
[AUT-1152](https://linear.app/automatisch/issue/AUT-1152/no-label-in-filter-when-the-other-one-is-removed)

The problem was caused by Slate editor focusing on empty placehorder Slate element (children). All the text was pushed to the left, but it was still affected by overflow hidden, that it why it was invisible. Since the slate element is always empty for Variable, since it is a void element, I put it at the beginning, so the text doesn't shift.

The issue occurred because the Slate editor focuses on an empty placeholder element (Slate's children), causing all the text to be aligned to the left and rendered invisible due to the `overflow: hidden` property. Since the placeholder Slate element for Variable is always empty (as variable is a void element), I repositioned it at the beginning to prevent the text from shifting.