### PR TITLE
feat: persist pagination and search value on flows page

### DIFF
--- a/packages/web/src/components/SearchInput/index.jsx
+++ b/packages/web/src/components/SearchInput/index.jsx
@@ -7,7 +7,7 @@ import FormControl from '@mui/material/FormControl';
 import SearchIcon from '@mui/icons-material/Search';
 import useFormatMessage from 'hooks/useFormatMessage';
 
-export default function SearchInput({ onChange }) {
+export default function SearchInput({ onChange, defaultValue = '' }) {
   const formatMessage = useFormatMessage();
   return (
     <FormControl variant="outlined" fullWidth>
@@ -16,6 +16,7 @@ export default function SearchInput({ onChange }) {
       </InputLabel>
 
       <OutlinedInput
+        defaultValue={defaultValue}
         id="search-input"
         type="text"
         size="medium"
@@ -34,4 +35,5 @@ export default function SearchInput({ onChange }) {
 
 SearchInput.propTypes = {
   onChange: PropTypes.func,
+  defaultValue: PropTypes.string,
 };


### PR DESCRIPTION
[AUT-1347](https://linear.app/automatisch/issue/AUT-1347/pagination-not-applied-on-a-page-reload)

To implement the required behavior, I also needed to persist the search value in addition to the page number.

When a user duplicates a flow, I’ve added a redirection to the first page, as flows are ordered by creation date, with the newest flow displayed first.