### PR TITLE
feat: make Wordpress instanceUrl field required

### DIFF
--- a/packages/backend/src/apps/wordpress/auth/index.js
+++ b/packages/backend/src/apps/wordpress/auth/index.js
@@ -8,7 +8,7 @@ export default {
       key: 'instanceUrl',
       label: 'WordPress instance URL',
       type: 'string',
-      required: false,
+      required: true,
       readOnly: false,
       value: null,
       placeholder: null,


### PR DESCRIPTION
[AUT-1280](https://linear.app/automatisch/issue/AUT-1280/non-required-url-for-wordpress-connection-leads-to-500-error)