### PR TITLE
feat: show api error message when logging in fails

### DIFF
--- a/packages/web/src/components/LoginForm/index.jsx
+++ b/packages/web/src/components/LoginForm/index.jsx
@@ -38,9 +38,21 @@ function LoginForm() {
       const { token } = data;
       authentication.updateToken(token);
     } catch (error) {
-      enqueueSnackbar(error?.message || formatMessage('loginForm.error'), {
-        variant: 'error',
-      });
+      const errors = error?.response?.data?.errors
+        ? Object.values(error.response.data.errors)
+        : [];
+
+      if (errors.length) {
+        for (const [error] of errors) {
+          enqueueSnackbar(error, {
+            variant: 'error',
+          });
+        }
+      } else {
+        enqueueSnackbar(error?.message || formatMessage('loginForm.error'), {
+          variant: 'error',
+        });
+      }
     }
   };
 


### PR DESCRIPTION
[AUT-1281](https://linear.app/automatisch/issue/AUT-1281/use-backend-message-in-snackbar-for-failed-login-attempt)