### PR TITLE
feat: introduce inline error messages for ForgotPassword and ResetPasswordForm

### DIFF
--- a/packages/web/src/components/ForgotPasswordForm/index.ee.jsx
+++ b/packages/web/src/components/ForgotPasswordForm/index.ee.jsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
+import Alert from '@mui/material/Alert';
 import LoadingButton from '@mui/lab/LoadingButton';
-import { enqueueSnackbar } from 'notistack';
 
 import useForgotPassword from 'hooks/useForgotPassword';
 import Form from 'components/Form';
@@ -15,6 +15,8 @@ export default function ForgotPasswordForm() {
     mutateAsync: forgotPassword,
     isPending: loading,
     isSuccess,
+    isError,
+    error,
   } = useForgotPassword();
 
   const handleSubmit = async (values) => {
@@ -23,14 +25,7 @@ export default function ForgotPasswordForm() {
       await forgotPassword({
         email,
       });
-    } catch (error) {
-      enqueueSnackbar(
-        error?.message || formatMessage('forgotPasswordForm.error'),
-        {
-          variant: 'error',
-        },
-      );
-    }
+    } catch {}
   };
 
   return (
@@ -57,6 +52,16 @@ export default function ForgotPasswordForm() {
           margin="dense"
           autoComplete="username"
         />
+        {isError && (
+          <Alert severity="error" sx={{ mt: 2 }}>
+            {error?.message || formatMessage('forgotPasswordForm.error')}
+          </Alert>
+        )}
+        {isSuccess && (
+          <Alert severity="success" sx={{ mt: 2 }}>
+            {formatMessage('forgotPasswordForm.instructionsSent')}
+          </Alert>
+        )}
         <LoadingButton
           type="submit"
           variant="contained"
@@ -68,14 +73,6 @@ export default function ForgotPasswordForm() {
         >
           {formatMessage('forgotPasswordForm.submit')}
         </LoadingButton>
-        {isSuccess && (
-          <Typography
-            variant="body1"
-            sx={{ color: (theme) => theme.palette.success.main }}
-          >
-            {formatMessage('forgotPasswordForm.instructionsSent')}
-          </Typography>
-        )}
       </Form>
     </Paper>
   );

--- a/packages/web/src/components/ForgotPasswordForm/index.ee.jsx
+++ b/packages/web/src/components/ForgotPasswordForm/index.ee.jsx
@@ -12,20 +12,17 @@ import useFormatMessage from 'hooks/useFormatMessage';
 export default function ForgotPasswordForm() {
   const formatMessage = useFormatMessage();
   const {
-    mutateAsync: forgotPassword,
+    mutate: forgotPassword,
     isPending: loading,
     isSuccess,
     isError,
     error,
   } = useForgotPassword();
 
-  const handleSubmit = async (values) => {
-    const { email } = values;
-    try {
-      await forgotPassword({
-        email,
-      });
-    } catch {}
+  const handleSubmit = ({ email }) => {
+    forgotPassword({
+      email,
+    });
   };
 
   return (

--- a/packages/web/src/components/LoginForm/index.jsx
+++ b/packages/web/src/components/LoginForm/index.jsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useNavigate, Link as RouterLink } from 'react-router-dom';
 import Paper from '@mui/material/Paper';
 import Link from '@mui/material/Link';
+import Alert from '@mui/material/Alert';
 import Typography from '@mui/material/Typography';
 import LoadingButton from '@mui/lab/LoadingButton';
 import useAuthentication from 'hooks/useAuthentication';
@@ -11,7 +12,6 @@ import Form from 'components/Form';
 import TextField from 'components/TextField';
 import useFormatMessage from 'hooks/useFormatMessage';
 import useCreateAccessToken from 'hooks/useCreateAccessToken';
-import { Alert } from '@mui/material';
 
 function LoginForm() {
   const isCloud = useCloud();
@@ -45,7 +45,7 @@ function LoginForm() {
 
   const renderError = () => {
     const errors = error?.response?.data?.errors?.general || [
-      formatMessage('loginForm.error'),
+      error?.message || formatMessage('loginForm.error'),
     ];
 
     return errors.map((error) => (

--- a/packages/web/src/components/ResetPasswordForm/index.ee.jsx
+++ b/packages/web/src/components/ResetPasswordForm/index.ee.jsx
@@ -2,6 +2,7 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import LoadingButton from '@mui/lab/LoadingButton';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
+import Alert from '@mui/material/Alert';
 import useEnqueueSnackbar from 'hooks/useEnqueueSnackbar';
 import * as React from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
@@ -30,6 +31,8 @@ export default function ResetPasswordForm() {
     mutateAsync: resetPassword,
     isPending,
     isSuccess,
+    error,
+    isError,
   } = useResetPassword();
   const token = searchParams.get('token');
 
@@ -47,14 +50,23 @@ export default function ResetPasswordForm() {
         },
       });
       navigate(URLS.LOGIN);
-    } catch (error) {
-      enqueueSnackbar(
-        error?.message || formatMessage('resetPasswordForm.error'),
-        {
-          variant: 'error',
-        },
-      );
+    } catch {}
+  };
+
+  const renderError = () => {
+    if (!isError) {
+      return null;
     }
+
+    const errors = error?.response?.data?.errors?.general || [
+      error?.message || formatMessage('resetPasswordForm.error'),
+    ];
+
+    return errors.map((error) => (
+      <Alert severity="error" sx={{ mt: 2 }}>
+        {error}
+      </Alert>
+    ));
   };
 
   return (
@@ -96,7 +108,6 @@ export default function ResetPasswordForm() {
                   : ''
               }
             />
-
             <TextField
               label={formatMessage(
                 'resetPasswordForm.confirmPasswordFieldLabel',
@@ -117,7 +128,7 @@ export default function ResetPasswordForm() {
                   : ''
               }
             />
-
+            {renderError()}
             <LoadingButton
               type="submit"
               variant="contained"


### PR DESCRIPTION
[AUT-1365](https://linear.app/automatisch/issue/AUT-1365/inline-error-messages-in-resetpasswordform-and-forgotpasswordform)

Additionaly I also changed Alert import for LoginForm, as I noticed it is not consistent with other material-ui components imports. Also I added `erros?.message` to be displayed if there is no errors object.

In ForgotPasswordForm for success message I also used Alert and moved it before the submit button, to unify the look with error alerts.

![forgot_password_error](https://github.com/user-attachments/assets/c76cbc1d-ab2e-49ee-96d6-3f006aeb550a)
![forgot_password_success](https://github.com/user-attachments/assets/dde5c8c6-3f9b-4fb4-a189-819b3f5c3a29)
![reset_error_general](https://github.com/user-attachments/assets/28fdd372-d2f5-4f3f-8fc6-0b8ce58e2907)
![reset_error_404](https://github.com/user-attachments/assets/59497830-8725-48f7-81e9-692bf6c41b75)
