### PR TITLE
feat: accept falsy default values

### DIFF
--- a/packages/e2e-tests/tests/app-integrations/webhook.spec.js
+++ b/packages/e2e-tests/tests/app-integrations/webhook.spec.js
@@ -12,7 +12,7 @@ test.describe('Webhook flow', () => {
   test('Create a new flow with a sync Webhook step then a Webhook step', async ({
     flowEditorPage,
     page,
-    request
+    request,
   }) => {
     await flowEditorPage.flowName.click();
     await flowEditorPage.flowNameInput.fill('syncWebhook');
@@ -23,10 +23,11 @@ test.describe('Webhook flow', () => {
     await expect(flowEditorPage.continueButton).toHaveCount(1);
     await expect(flowEditorPage.continueButton).not.toBeEnabled();
 
-    await page
-      .getByTestId('parameters.statusCode-power-input')
-      .locator('[contenteditable]')
-      .fill('200');
+    await expect(
+      page
+        .getByTestId('parameters.statusCode-power-input')
+        .locator('[contenteditable]')
+    ).toHaveText('200');
     await flowEditorPage.clickAway();
     await expect(flowEditorPage.continueButton).toHaveCount(1);
     await expect(flowEditorPage.continueButton).not.toBeEnabled();
@@ -36,7 +37,9 @@ test.describe('Webhook flow', () => {
       .locator('[contenteditable]')
       .fill('response from webhook');
     await flowEditorPage.clickAway();
-    await expect(page.getByTestId("parameters.headers.0.key-power-input")).toBeVisible();
+    await expect(
+      page.getByTestId('parameters.headers.0.key-power-input')
+    ).toBeVisible();
     await expect(flowEditorPage.continueButton).toBeEnabled();
     await flowEditorPage.continueButton.click();
 
@@ -52,7 +55,7 @@ test.describe('Webhook flow', () => {
   test('Create a new flow with an async Webhook step then a Webhook step', async ({
     flowEditorPage,
     page,
-    request
+    request,
   }) => {
     await flowEditorPage.flowName.click();
     await flowEditorPage.flowNameInput.fill('asyncWebhook');
@@ -75,7 +78,9 @@ test.describe('Webhook flow', () => {
       .locator('[contenteditable]')
       .fill('response from webhook');
     await flowEditorPage.clickAway();
-    await expect(page.getByTestId("parameters.headers.0.key-power-input")).toBeVisible();
+    await expect(
+      page.getByTestId('parameters.headers.0.key-power-input')
+    ).toBeVisible();
     await expect(flowEditorPage.continueButton).toBeEnabled();
     await flowEditorPage.continueButton.click();
 

--- a/packages/web/src/components/CodeEditor/index.jsx
+++ b/packages/web/src/components/CodeEditor/index.jsx
@@ -14,7 +14,7 @@ function CodeEditor(props) {
     required,
     name,
     label,
-    defaultValue,
+    defaultValue = '',
     shouldUnregister = false,
     disabled,
     'data-test': dataTest,
@@ -39,7 +39,7 @@ function CodeEditor(props) {
     <Controller
       rules={{ required }}
       name={name}
-      defaultValue={defaultValue || ''}
+      defaultValue={defaultValue}
       control={control}
       shouldUnregister={shouldUnregister}
       render={({ field }) => (

--- a/packages/web/src/components/ControlledAutocomplete/index.jsx
+++ b/packages/web/src/components/ControlledAutocomplete/index.jsx
@@ -53,7 +53,7 @@ function ControlledAutocomplete(props) {
     <Controller
       rules={{ required }}
       name={name}
-      defaultValue={defaultValue || ''}
+      defaultValue={defaultValue}
       control={control}
       shouldUnregister={shouldUnregister}
       render={({

--- a/packages/web/src/components/DynamicField/index.jsx
+++ b/packages/web/src/components/DynamicField/index.jsx
@@ -23,11 +23,28 @@ function DynamicField(props) {
     return fields.reduce((previousValue, field) => {
       return {
         ...previousValue,
-        [field.key]: '',
+        [field.key]: field.value ?? '',
         __id: uuidv4(),
       };
     }, {});
   }, [fields]);
+
+  const generateDefaultValue = React.useCallback(() => {
+    if (defaultValue?.length > 0) {
+      return defaultValue.map((item) => {
+        return fields.reduce((previousValue, field) => {
+          return {
+            ...previousValue,
+            // if field value is different than null or undefined - use it,
+            // otherwise use the parent default value
+            [field.key]: field.value ?? item[field.key] ?? '',
+          };
+        }, {});
+      });
+    } else {
+      return [createEmptyItem()];
+    }
+  }, [defaultValue, fields, createEmptyItem]);
 
   const addItem = React.useCallback(() => {
     const values = getValues(name);
@@ -52,13 +69,11 @@ function DynamicField(props) {
   React.useEffect(
     function addInitialGroupWhenEmpty() {
       const fieldValues = getValues(name);
-      if (!fieldValues && defaultValue) {
-        setValue(name, defaultValue);
-      } else if (!fieldValues) {
-        setValue(name, [createEmptyItem()]);
+      if (!fieldValues) {
+        setValue(name, generateDefaultValue());
       }
     },
-    [createEmptyItem, defaultValue],
+    [generateDefaultValue],
   );
 
   return (

--- a/packages/web/src/components/InputCreator/index.jsx
+++ b/packages/web/src/components/InputCreator/index.jsx
@@ -162,6 +162,7 @@ function InputCreator(props) {
             required={required}
             disabled={disabled}
             shouldUnregister={shouldUnregister}
+            defaultValue={value}
           />
 
           {isDynamicFieldsLoading && !additionalFields?.length && (

--- a/packages/web/src/components/TextField/index.jsx
+++ b/packages/web/src/components/TextField/index.jsx
@@ -23,7 +23,7 @@ function TextField(props) {
   const {
     required,
     name,
-    defaultValue,
+    defaultValue = '',
     shouldUnregister = false,
     clickToCopy = false,
     readOnly = false,
@@ -38,7 +38,7 @@ function TextField(props) {
     <Controller
       rules={{ required }}
       name={name}
-      defaultValue={defaultValue || ''}
+      defaultValue={defaultValue}
       control={control}
       shouldUnregister={shouldUnregister}
       render={({


### PR DESCRIPTION
[AUT-1409](https://linear.app/automatisch/issue/AUT-1409/incorporate-default-values-for-fields-in-step-arguments)

I tested various configurations of substep arguments and now it seems to me that default values are consistently applied. For `DynamicField`, the default value of the field takes precedence and is used if it exists. If not, the parent node's default value is applied. Otherwise, an empty string is used. When fields have default values, these defaults are applied each time fields are added:

![image](https://github.com/user-attachments/assets/20459278-f51f-484d-8633-ee864ecf1ab8)

I recorded a video showing how the default values are applied:
https://www.loom.com/share/6b933a74b9c74fae9e3a44b3e4f3ec25

Each time I open and close the step, because default values are applied on Form mount. 
