### PR TITLE
Adding one-click deploy button for RepoCloud.io to installation.md

### DIFF
--- a/packages/docs/pages/guide/installation.md
+++ b/packages/docs/pages/guide/installation.md
@@ -104,6 +104,18 @@ We use default values of render plans with the `render.yaml` file, if you want t
 
 :::
 
+## RepoCloud
+
+<a href="https://repocloud.io/details/?app_id=251">
+  <img src="https://d16t0pc4846x52.cloudfront.net/deploylobe.svg" alt="Deploy to RepoCloud">
+</a>
+
+:::info
+
+RepoCloud offers one-click deployment with free plans for new users. Simply enter a project name and click deploy.
+
+:::
+
 ## Production setup
 
 If you need to change any other environment variables for your production setup, let's check out the [environment variables](/advanced/configuration#environment-variables) section of the configuration page.


### PR DESCRIPTION
Adding button enabling community access to deploy template for self-hosting on RepoCloud with one click