### PR TITLE
feat: apply React Flow's 'nowheel' class to enable scroll in test output

### DIFF
--- a/packages/web/src/components/TestSubstep/index.jsx
+++ b/packages/web/src/components/TestSubstep/index.jsx
@@ -113,6 +113,7 @@ function TestSubstep(props) {
             <Box
               sx={{ maxHeight: 400, overflowY: 'auto', width: '100%' }}
               data-test="flow-test-substep-output"
+              className="nowheel"
             >
               <JSONViewer data={dataOut} />
             </Box>


### PR DESCRIPTION
[AUT-1423](https://linear.app/automatisch/issue/AUT-1423/cannot-scroll-on-steps-when-using-react-app-use-new-flow-editor=true)