### PR TITLE
fix: remove not used props passed to EditableTypography and fix propTypes

### DIFF
--- a/packages/web/src/components/EditableTypography/index.jsx
+++ b/packages/web/src/components/EditableTypography/index.jsx
@@ -95,7 +95,7 @@ function EditableTypography(props) {
 }
 
 EditableTypography.propTypes = {
-  children: PropTypes.string.isRequired,
+  children: PropTypes.string,
   disabled: PropTypes.bool,
   iconColor: PropTypes.oneOf(['action', 'inherit']),
   onConfirm: PropTypes.func,

--- a/packages/web/src/components/FlowStep/index.jsx
+++ b/packages/web/src/components/FlowStep/index.jsx
@@ -265,8 +265,6 @@ function FlowStep(props) {
             </Typography>
 
             <EditableTypography
-              iconPosition="end"
-              iconSize="small"
               variant="body2"
               onConfirm={handleStepNameChange}
               prefixValue={`${step.position}. `}


### PR DESCRIPTION
Usage of EditableTypography was causing some console errors:

![image](https://github.com/user-attachments/assets/b2593f13-6c8b-450a-b694-5068ebce67b8)

![image](https://github.com/user-attachments/assets/f2a44f36-78a6-4914-b9d1-17856cf692e3)

![image](https://github.com/user-attachments/assets/a9da452c-bc10-4437-b7fb-9f5eeff8a017)
