### PR TITLE
feat: in slate deserialization preserve original null and numeric values

### DIFF
--- a/packages/web/src/components/Slate/utils.js
+++ b/packages/web/src/components/Slate/utils.js
@@ -70,7 +70,25 @@ export const deserialize = (value, options, stepsWithVariables) => {
     ];
   }
 
-  if (value === null || value === undefined || value === '')
+  if (typeof value === 'number') {
+    return [
+      {
+        type: 'paragraph',
+        children: [{ text: value.toString(), value }],
+      },
+    ];
+  }
+
+  if (value === null) {
+    return [
+      {
+        type: 'paragraph',
+        children: [{ text: '', value }],
+      },
+    ];
+  }
+
+  if (value === undefined || value === '')
     return [
       {
         type: 'paragraph',


### PR DESCRIPTION
[AUT-1415](https://linear.app/automatisch/issue/AUT-1415/preselected-values-are-not-properly-displayed)

In Google Sheets, the default drive is 'My Google Drive', and its value is set to null. To ensure this option is correctly selectable from the fetched options, it is important to maintain the null value in the Slate editor.

![image](https://github.com/user-attachments/assets/1442d1fb-a4d3-419a-9112-ada4abc628ec)

Additionally, worksheet values are represented as numbers. These numerical values must be preserved to ensure correct selection from the options and accurate data transmission.

![image](https://github.com/user-attachments/assets/d0d91e17-ce2c-4f95-aaa2-902c26ee3015)


