### PR TITLE
feat: display secondary ListItemText content only if is a string

### DIFF
--- a/packages/web/src/components/ControlledCustomAutocomplete/Options.jsx
+++ b/packages/web/src/components/ControlledCustomAutocomplete/Options.jsx
@@ -37,7 +37,7 @@ const Item = (props) => {
           title: 'Property name',
           sx: { fontWeight: 700 },
         }}
-        secondary={suboption.value}
+        secondary={typeof suboption.value === 'string' ? suboption.value : ''}
         secondaryTypographyProps={{
           variant: 'subtitle2',
           title: 'Sample value',


### PR DESCRIPTION
[AUT-1419](https://linear.app/automatisch/issue/AUT-1419/react-issues-on-click-attributevalue-for-signalwire-add-xml-node)

If the secondary content needs to be displayed as a string, even when it is of a different type such as number or boolean, please let me know. I can then convert the value to a string instead of checking its type.