### PR TITLE
feat: display option value only if it is a string

### DIFF
--- a/packages/web/src/components/ControlledAutocomplete/index.jsx
+++ b/packages/web/src/components/ControlledAutocomplete/index.jsx
@@ -102,7 +102,7 @@ function ControlledAutocomplete(props) {
               >
                 <Typography>{option.label}</Typography>
 
-                {showOptionValue && (
+                {showOptionValue && typeof option.value === 'string' && (
                   <Typography variant="caption">{option.value}</Typography>
                 )}
               </li>


### PR DESCRIPTION
[AUT-1416](https://linear.app/automatisch/issue/AUT-1416/failed-prop-type-invalid-prop-children-supplied-to)

If option value content needs to be displayed as a string, even when it is of a different type such as number or boolean, please let me know. I can then convert the value to a string instead of checking its type.