### PR TITLE
fix: correctly set initial option value in ChooseConnectionSubstep

### DIFF
--- a/packages/web/src/components/ChooseConnectionSubstep/index.jsx
+++ b/packages/web/src/components/ChooseConnectionSubstep/index.jsx
@@ -34,7 +34,7 @@ const optionGenerator = (connection) => ({
 });
 
 const getOption = (options, connectionId) =>
-  options.find((connection) => connection.value === connectionId) || undefined;
+  options.find((connection) => connection.value === connectionId) || '';
 
 function ChooseConnectionSubstep(props) {
   const {


### PR DESCRIPTION
[AUT-1424](https://linear.app/automatisch/issue/AUT-1424/freshly-added-connection-is-not-selected)