### PR TITLE
fix: do not use variables in Formatter transform options

### DIFF
--- a/packages/backend/src/apps/formatter/actions/date-time/index.js
+++ b/packages/backend/src/apps/formatter/actions/date-time/index.js
@@ -19,7 +19,7 @@ export default defineAction({
       key: 'transform',
       type: 'dropdown',
       required: true,
-      variables: true,
+      variables: false,
       options: [
         {
           label: 'Get current timestamp',

--- a/packages/backend/src/apps/formatter/actions/numbers/index.js
+++ b/packages/backend/src/apps/formatter/actions/numbers/index.js
@@ -23,7 +23,7 @@ export default defineAction({
       key: 'transform',
       type: 'dropdown',
       required: true,
-      variables: true,
+      variables: false,
       options: [
         { label: 'Perform Math Operation', value: 'performMathOperation' },
         { label: 'Random Number', value: 'randomNumber' },

--- a/packages/backend/src/apps/formatter/actions/text/index.js
+++ b/packages/backend/src/apps/formatter/actions/text/index.js
@@ -47,7 +47,7 @@ export default defineAction({
       key: 'transform',
       type: 'dropdown',
       required: true,
-      variables: true,
+      variables: false,
       options: [
         { label: 'Base64 to String', value: 'base64ToString' },
         { label: 'Capitalize', value: 'capitalize' },

--- a/packages/backend/src/apps/formatter/dynamic-fields/list-replace-regex-options/index.js
+++ b/packages/backend/src/apps/formatter/dynamic-fields/list-replace-regex-options/index.js
@@ -12,7 +12,7 @@ export default {
         type: 'dropdown',
         required: true,
         description: 'Ignore case sensitivity.',
-        variables: true,
+        variables: false,
         options: [
           { label: 'Yes', value: true },
           { label: 'No', value: false },

--- a/packages/backend/src/apps/formatter/dynamic-fields/list-transform-options/date-time/format-date-time.js
+++ b/packages/backend/src/apps/formatter/dynamic-fields/list-transform-options/date-time/format-date-time.js
@@ -25,7 +25,7 @@ const formatDateTime = [
     type: 'dropdown',
     required: true,
     description: 'The timezone of the input.',
-    variables: true,
+    variables: false,
     options: timezoneOptions,
   },
   {
@@ -43,7 +43,7 @@ const formatDateTime = [
     type: 'dropdown',
     required: true,
     description: 'The timezone of the output.',
-    variables: true,
+    variables: false,
     options: timezoneOptions,
   },
 ];

--- a/packages/backend/src/apps/formatter/dynamic-fields/list-transform-options/numbers/format-number.js
+++ b/packages/backend/src/apps/formatter/dynamic-fields/list-transform-options/numbers/format-number.js
@@ -13,7 +13,7 @@ const formatNumber = [
     type: 'dropdown',
     required: true,
     description: 'The decimal mark of the input number.',
-    variables: true,
+    variables: false,
     options: [
       { label: 'Comma', value: ',' },
       { label: 'Period', value: '.' },
@@ -25,7 +25,7 @@ const formatNumber = [
     type: 'dropdown',
     required: true,
     description: 'The format you want to convert the number to.',
-    variables: true,
+    variables: false,
     options: [
       { label: 'Comma for grouping & period for decimal', value: '0' },
       { label: 'Period for grouping & comma for decimal', value: '1' },

--- a/packages/backend/src/apps/formatter/dynamic-fields/list-transform-options/numbers/format-phone-number.js
+++ b/packages/backend/src/apps/formatter/dynamic-fields/list-transform-options/numbers/format-phone-number.js
@@ -15,7 +15,7 @@ const formatPhoneNumber = [
     type: 'dropdown',
     required: true,
     description: 'The format you want to convert the number to.',
-    variables: true,
+    variables: false,
     options: [
       { label: '+491632223344 (E164)', value: 'e164' },
       { label: '+49 163 2223344 (International)', value: 'international' },
@@ -28,7 +28,7 @@ const formatPhoneNumber = [
     type: 'dropdown',
     required: true,
     description: 'The country code of the phone number. The default is US.',
-    variables: true,
+    variables: false,
     options: phoneNumberCountryCodes,
   },
 ];

--- a/packages/backend/src/apps/formatter/dynamic-fields/list-transform-options/numbers/perform-math-operation.js
+++ b/packages/backend/src/apps/formatter/dynamic-fields/list-transform-options/numbers/perform-math-operation.js
@@ -5,7 +5,7 @@ const performMathOperation = [
     type: 'dropdown',
     required: true,
     description: 'The math operation to perform.',
-    variables: true,
+    variables: false,
     options: [
       { label: 'Add', value: 'add' },
       { label: 'Divide', value: 'divide' },

--- a/packages/backend/src/apps/formatter/dynamic-fields/list-transform-options/text/replace.js
+++ b/packages/backend/src/apps/formatter/dynamic-fields/list-transform-options/text/replace.js
@@ -29,7 +29,7 @@ const replace = [
     type: 'dropdown',
     required: true,
     description: 'Use regex to search values.',
-    variables: true,
+    variables: false,
     value: false,
     options: [
       { label: 'Yes', value: true },


### PR DESCRIPTION
I didn't change it for Date/Time format options as it was working fine with custom variables to some point.