### PR TITLE
feat: debounce onAddStep in EditorNew

### DIFF
--- a/packages/web/src/components/EditorNew/EditorNew.jsx
+++ b/packages/web/src/components/EditorNew/EditorNew.jsx
@@ -3,6 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { FlowPropType } from 'propTypes/propTypes';
 import ReactFlow, { useNodesState, useEdgesState } from 'reactflow';
 import 'reactflow/dist/style.css';
+import { debounce } from 'lodash';
 
 import useCreateStep from 'hooks/useCreateStep';
 import useUpdateStep from 'hooks/useUpdateStep';
@@ -108,11 +109,10 @@ const EditorNew = ({ flow }) => {
   );
 
   const onAddStep = useCallback(
-    async (previousStepId) => {
+    debounce(async (previousStepId) => {
       const { data: createdStep } = await createStep({ previousStepId });
-
       createdStepIdRef.current = createdStep.id;
-    },
+    }, 300),
     [createStep],
   );
 


### PR DESCRIPTION
[AUT-1433](https://linear.app/automatisch/issue/AUT-1433/react-error-when-adding-action-steps)

I implemented a debounce on the onAddStep function to address this issue. However, the "Maximum update depth exceeded" error can still occur if a user quickly triggers updates on different nodes. I plan to create a separate task to optimize the updates for nodes and edges.