### PR TITLE
feat: handle 404 error in useFlowFolder

### DIFF
--- a/packages/web/src/hooks/useFlowFolder.js
+++ b/packages/web/src/hooks/useFlowFolder.js
@@ -6,11 +6,18 @@ export default function useFlowFolder(flowId) {
   const query = useQuery({
     queryKey: ['flows', flowId, 'folder'],
     queryFn: async ({ signal }) => {
-      const { data } = await api.get(`/v1/flows/${flowId}/folder`, {
-        signal,
-      });
+      try {
+        const { data } = await api.get(`/v1/flows/${flowId}/folder`, {
+          signal,
+        });
 
-      return data;
+        return data;
+      } catch (error) {
+        if (error.response?.status === 404) {
+          return null;
+        }
+        throw error;
+      }
     },
   });
 


### PR DESCRIPTION
[AUT-1465](https://linear.app/automatisch/issue/AUT-1465/after-folder-removal-flow-seems-to-be-still-in-the-folder)