### PR TITLE
fix: clear parameters on event change in ChooseAppAndEventSubstep

### DIFF
--- a/packages/web/src/components/ChooseAppAndEventSubstep/index.jsx
+++ b/packages/web/src/components/ChooseAppAndEventSubstep/index.jsx
@@ -102,6 +102,7 @@ function ChooseAppAndEventSubstep(props) {
               ...step,
               key: eventKey,
               keyLabel: eventLabel,
+              parameters: {},
             },
           });
         }


### PR DESCRIPTION
[AUT-1479](https://linear.app/automatisch/issue/AUT-1479/transform-value-remembered-when-action-event-is-changed)