### PR TITLE
feat: align the style of ControlledAutocomplete with ControlledCustomAutocomplete

### DIFF
--- a/packages/web/src/components/ControlledAutocomplete/index.jsx
+++ b/packages/web/src/components/ControlledAutocomplete/index.jsx
@@ -4,6 +4,7 @@ import { Controller, useFormContext } from 'react-hook-form';
 import FormHelperText from '@mui/material/FormHelperText';
 import Autocomplete, { createFilterOptions } from '@mui/material/Autocomplete';
 import Typography from '@mui/material/Typography';
+import { Option } from './style';
 
 const getOption = (options, value) =>
   options.find((option) => option.value === value) || null;
@@ -95,19 +96,27 @@ function ControlledAutocomplete(props) {
             ref={ref}
             data-test={`${name}-autocomplete`}
             renderOption={(optionProps, option) => (
-              <li
+              <Option
                 {...optionProps}
                 key={option.value?.toString()}
-                style={{ flexDirection: 'column', alignItems: 'start' }}
+                showOptionValue={showOptionValue}
               >
-                <Typography>{option.label}</Typography>
+                <Typography
+                  variant={showOptionValue ? 'subtitle1' : 'body1'}
+                  {...(showOptionValue && { sx: { fontWeight: 700 } })}
+                >
+                  {option.label}
+                </Typography>
 
                 {showOptionValue && typeof option.value === 'string' && (
-                  <Typography variant="caption">{option.value}</Typography>
+                  <Typography variant="subtitle2" color="text.secondary">
+                    {option.value}
+                  </Typography>
                 )}
-              </li>
+              </Option>
             )}
             renderInput={(params) => renderInput(params, fieldState)}
+            {...(showOptionValue && { ListboxProps: { sx: { p: 0 } } })}
           />
           {showHelperText && (
             <FormHelperText

--- a/packages/web/src/components/ControlledAutocomplete/style.js
+++ b/packages/web/src/components/ControlledAutocomplete/style.js
@@ -1,0 +1,12 @@
+import { styled } from '@mui/material/styles';
+
+export const Option = styled('li', {
+  shouldForwardProp: (prop) => prop !== 'showOptionValue',
+})(({ theme, showOptionValue }) => ({
+  ...(showOptionValue && {
+    borderBottom: `1px solid ${theme.palette.divider}`,
+    flexDirection: 'column',
+    alignItems: 'start !important',
+    padding: `${theme.spacing(2)} !important`,
+  }),
+}));


### PR DESCRIPTION
[AUT-1461](https://linear.app/automatisch/issue/AUT-1461/make-the-human-readable-names-bold-when-variable-is-false)

Since the ControlledAutocomplete component may or may not display the option value, I render the listbox items differently based on the showOptionValue setting. I aligned the styles with ControlledCustomAutocomplete.

![controlled_autocomplete_2](https://github.com/user-attachments/assets/8d896aee-cad4-45c4-806a-6789ee7dadb1)

![controlled_autocomplete](https://github.com/user-attachments/assets/12f7e55d-4d4c-4d4c-bbab-1b4566175923)
