### PR TITLE
fix: apps icons position

### DIFF
--- a/packages/docs/pages/.vitepress/theme/custom.css
+++ b/packages/docs/pages/.vitepress/theme/custom.css
@@ -121,9 +121,17 @@
   --announcement-bar-height: 50px;
 }
 
+.dark .VPTeamMembersItem .avatar {
+  background-color: var(--vp-c-white);
+}
+
 .VPTeamMembersItem .avatar-img {
   top: 50%;
-  transform: translateY(-50%);
+  left: 50%;
+  transform: translate(-50%, -50%);
+  border-radius: initial;
+  max-width: 65%;
+  max-height: 65%;
 }
 
 header.VPNav {


### PR DESCRIPTION
The icons vary significantly, so to ensure a cohesive look, I removed the rounding and reduced their size to fit within the circle.

For dark mode, I set the background circle to white to maintain clear visibility of all icons.

![image](https://github.com/user-attachments/assets/ed95b42f-4505-42a6-ae1c-8e69d23d9e5d)

![image](https://github.com/user-attachments/assets/34a07fd9-5507-4d74-8a22-f55beb1ca636)



