### PR TITLE
fix: expand only first level of nodes on load

### DIFF
--- a/packages/web/src/components/JSONViewer/index.jsx
+++ b/packages/web/src/components/JSONViewer/index.jsx
@@ -46,7 +46,7 @@ function JSONViewer(props) {
     <JSONTree
       hideRoot
       data={data}
-      shouldExpandNode={() => true}
+      shouldExpandNode={(keyPath) => keyPath.length < 3}
       invertTheme={false}
       theme={theme}
     />


### PR DESCRIPTION
[AUT-1195](https://linear.app/automatisch/issue/AUT-1195/flow-page-unresponsive-when-request-is-executed)

@barinali @kuba618  The page becomes unresponsive when JSONViewer has to render a large amount of deeply nested data. My solution is to expand only the first level of nodes by default. I can also add an "Expand All" button, allowing users to expand everything if needed. However, please note that doing so may still cause the page to become temporarily unresponsive.

Let me know if you'd like me to add this feature. If keeping the JSON output fully expanded - despite occasional unresponsiveness - is not a major concern, I can close this pull request.