### PR TITLE
Fix: Inconsistent use of `process.env`

### DIFF
--- a/packages/web/vite.config.js
+++ b/packages/web/vite.config.js
@@ -5,10 +5,6 @@ import eslint from 'vite-plugin-eslint';
 
 export default defineConfig(() => {
   return {
-    // https://github.com/vitejs/vite/issues/1973#issuecomment-787571499
-    define: {
-      'process.env': {},
-    },
     build: {
       outDir: 'build',
     },


### PR DESCRIPTION
In `packages\web\vite.config.js`, `process.env` is defined as an empty object, which might lead to unexpected behavior or errors if the code relies on default values or existence checks for environment variables. The use of `process.env.APP_ENV` as a conditional for eslint plugin application seems questionable.

Fix:
--- a/packages\web\vite.config.js
+++ b/packages\web\vite.config.js
@@ -5,10 +5,6 @@
 
 export default defineConfig(() => {
   return {
-    // https://github.com/vitejs/vite/issues/1973#issuecomment-787571499
-    define: {
-      'process.env': {},
-    },
     build: {
       outDir: 'build',
     },