### PR TITLE
Fix: Inconsistent naming for `computeAuthStepVariables`

### DIFF
--- a/packages/web/src/helpers/computeVariables.js
+++ b/packages/web/src/helpers/computeVariables.js
@@ -2,11 +2,11 @@ import template from 'lodash/template';
 const interpolate = /{([\s\S]+?)}/g;
 const computeAuthStepVariables = (variableSchema, aggregatedData) => {
   const variables = {};
-  for (const variable of variableSchema) {
+   for (const variable of variableSchema) {
     if (variable.properties) {
       variables[variable.name] = computeAuthStepVariables(
         variable.properties,
-        aggregatedData
+         aggregatedData
       );
       continue;
     }
@@ -18,5 +18,5 @@ const computeAuthStepVariables = (variableSchema, aggregatedData) => {
     }
   }
   return variables;
-};
+export default computeVariables;
 export default computeAuthStepVariables;


### PR DESCRIPTION
There are two functions named `computeAuthStepVariables` defined in `packages\web\src\helpers\computeAuthStepVariables.js` and `packages\web\src\helpers\computeVariables.js`. This could lead to confusion and unexpected behavior if the wrong function is imported or called. The functions appear to be very similar in implementation.

Fix:
--- a/packages/web/src/helpers/computeVariables.js
+++ b/packages/web/src/helpers/computeVariables.js
@@ -2,11 +2,11 @@
 const interpolate = /{([\s\S]+?)}/g;
 const computeAuthStepVariables = (variableSchema, aggregatedData) => {
   const variables = {};
-  for (const variable of variableSchema) {
+   for (const variable of variableSchema) {
     if (variable.properties) {
       variables[variable.name] = computeAuthStepVariables(
         variable.properties,
-        aggregatedData
+         aggregatedData
       );
       continue;
     }
@@ -18,4 +18,4 @@
   }
   return variables;
 };
-export default computeAuthStepVariables;
+export default computeVariables;