### PR TITLE
Fix Google Authetication missing refresh token 

### DIFF
--- a/packages/backend/src/apps/gmail/auth/generate-auth-url.js
+++ b/packages/backend/src/apps/gmail/auth/generate-auth-url.js
@@ -9,7 +9,7 @@ export default async function generateAuthUrl($) {
   const searchParams = new URLSearchParams({
     client_id: $.auth.data.clientId,
     redirect_uri: redirectUri,
-    prompt: 'select_account',
+    prompt: 'select_account+consent',
     scope: authScope.join(' '),
     response_type: 'code',
     access_type: 'offline',

--- a/packages/backend/src/apps/gmail/auth/generate-auth-url.js
+++ b/packages/backend/src/apps/gmail/auth/generate-auth-url.js
@@ -9,7 +9,7 @@ export default async function generateAuthUrl($) {
   const searchParams = new URLSearchParams({
     client_id: $.auth.data.clientId,
     redirect_uri: redirectUri,
-    prompt: 'select_account+consent',
+    prompt: 'select_account consent',
     scope: authScope.join(' '),
     response_type: 'code',
     access_type: 'offline',

--- a/packages/backend/src/apps/google-calendar/auth/generate-auth-url.js
+++ b/packages/backend/src/apps/google-calendar/auth/generate-auth-url.js
@@ -9,7 +9,7 @@ export default async function generateAuthUrl($) {
   const searchParams = new URLSearchParams({
     client_id: $.auth.data.clientId,
     redirect_uri: redirectUri,
-    prompt: 'select_account',
+    prompt: 'select_account+consent',
     scope: authScope.join(' '),
     response_type: 'code',
     access_type: 'offline',

--- a/packages/backend/src/apps/google-calendar/auth/generate-auth-url.js
+++ b/packages/backend/src/apps/google-calendar/auth/generate-auth-url.js
@@ -9,7 +9,7 @@ export default async function generateAuthUrl($) {
   const searchParams = new URLSearchParams({
     client_id: $.auth.data.clientId,
     redirect_uri: redirectUri,
-    prompt: 'select_account+consent',
+    prompt: 'select_account consent',
     scope: authScope.join(' '),
     response_type: 'code',
     access_type: 'offline',

--- a/packages/backend/src/apps/google-drive/auth/generate-auth-url.js
+++ b/packages/backend/src/apps/google-drive/auth/generate-auth-url.js
@@ -9,7 +9,7 @@ export default async function generateAuthUrl($) {
   const searchParams = new URLSearchParams({
     client_id: $.auth.data.clientId,
     redirect_uri: redirectUri,
-    prompt: 'select_account',
+    prompt: 'select_account+consent',
     scope: authScope.join(' '),
     response_type: 'code',
     access_type: 'offline',

--- a/packages/backend/src/apps/google-drive/auth/generate-auth-url.js
+++ b/packages/backend/src/apps/google-drive/auth/generate-auth-url.js
@@ -9,7 +9,7 @@ export default async function generateAuthUrl($) {
   const searchParams = new URLSearchParams({
     client_id: $.auth.data.clientId,
     redirect_uri: redirectUri,
-    prompt: 'select_account+consent',
+    prompt: 'select_account consent',
     scope: authScope.join(' '),
     response_type: 'code',
     access_type: 'offline',

--- a/packages/backend/src/apps/google-forms/auth/generate-auth-url.js
+++ b/packages/backend/src/apps/google-forms/auth/generate-auth-url.js
@@ -9,7 +9,7 @@ export default async function generateAuthUrl($) {
   const searchParams = new URLSearchParams({
     client_id: $.auth.data.clientId,
     redirect_uri: redirectUri,
-    prompt: 'select_account',
+    prompt: 'select_account+consent',
     scope: authScope.join(' '),
     response_type: 'code',
     access_type: 'offline',

--- a/packages/backend/src/apps/google-forms/auth/generate-auth-url.js
+++ b/packages/backend/src/apps/google-forms/auth/generate-auth-url.js
@@ -9,7 +9,7 @@ export default async function generateAuthUrl($) {
   const searchParams = new URLSearchParams({
     client_id: $.auth.data.clientId,
     redirect_uri: redirectUri,
-    prompt: 'select_account+consent',
+    prompt: 'select_account consent',
     scope: authScope.join(' '),
     response_type: 'code',
     access_type: 'offline',

--- a/packages/backend/src/apps/google-sheets/auth/generate-auth-url.js
+++ b/packages/backend/src/apps/google-sheets/auth/generate-auth-url.js
@@ -9,7 +9,7 @@ export default async function generateAuthUrl($) {
   const searchParams = new URLSearchParams({
     client_id: $.auth.data.clientId,
     redirect_uri: redirectUri,
-    prompt: 'select_account',
+    prompt: 'select_account+consent',
     scope: authScope.join(' '),
     response_type: 'code',
     access_type: 'offline',

--- a/packages/backend/src/apps/google-sheets/auth/generate-auth-url.js
+++ b/packages/backend/src/apps/google-sheets/auth/generate-auth-url.js
@@ -9,7 +9,7 @@ export default async function generateAuthUrl($) {
   const searchParams = new URLSearchParams({
     client_id: $.auth.data.clientId,
     redirect_uri: redirectUri,
-    prompt: 'select_account+consent',
+    prompt: 'select_account consent',
     scope: authScope.join(' '),
     response_type: 'code',
     access_type: 'offline',

--- a/packages/backend/src/apps/google-tasks/auth/generate-auth-url.js
+++ b/packages/backend/src/apps/google-tasks/auth/generate-auth-url.js
@@ -9,7 +9,7 @@ export default async function generateAuthUrl($) {
   const searchParams = new URLSearchParams({
     client_id: $.auth.data.clientId,
     redirect_uri: redirectUri,
-    prompt: 'select_account',
+    prompt: 'select_account+consent',
     scope: authScope.join(' '),
     response_type: 'code',
     access_type: 'offline',

--- a/packages/backend/src/apps/google-tasks/auth/generate-auth-url.js
+++ b/packages/backend/src/apps/google-tasks/auth/generate-auth-url.js
@@ -9,7 +9,7 @@ export default async function generateAuthUrl($) {
   const searchParams = new URLSearchParams({
     client_id: $.auth.data.clientId,
     redirect_uri: redirectUri,
-    prompt: 'select_account+consent',
+    prompt: 'select_account consent',
     scope: authScope.join(' '),
     response_type: 'code',
     access_type: 'offline',

--- a/packages/backend/src/apps/youtube/auth/generate-auth-url.js
+++ b/packages/backend/src/apps/youtube/auth/generate-auth-url.js
@@ -12,7 +12,7 @@ export default async function generateAuthUrl($) {
     response_type: 'code',
     scope: authScope.join(' '),
     access_type: 'offline',
-    prompt: 'select_account+consent',
+    prompt: 'select_account consent',
   });
 
   const url = `https://accounts.google.com/o/oauth2/v2/auth?${searchParams.toString()}`;

--- a/packages/backend/src/apps/youtube/auth/generate-auth-url.js
+++ b/packages/backend/src/apps/youtube/auth/generate-auth-url.js
@@ -12,7 +12,7 @@ export default async function generateAuthUrl($) {
     response_type: 'code',
     scope: authScope.join(' '),
     access_type: 'offline',
-    prompt: 'select_account',
+    prompt: 'select_account+consent',
   });
 
   const url = `https://accounts.google.com/o/oauth2/v2/auth?${searchParams.toString()}`;


### PR DESCRIPTION
This change should fix https://github.com/automatisch/automatisch/issues/1579 issue.

## How to reproduce the bug
1. Authenticate for any Google product (eg. Google Sheets)
2. Go to **"My Apps"** -> **"Google Sheets"**
3. Select **"Connections"** tab
4. Delete the connection
5. Re-authenticate for the same product again with the same account.

After 60 minutes  run your automation. Your `access_token` will expire and refresh token request will return error:
```
{
  "error": "invalid_grant"
  "error_description": "Bad Request"
}
```

I've described why this happening in my reply to the issue here: https://github.com/automatisch/automatisch/issues/1579#issuecomment-2993675456

## Screenshots
This will demonstrate visually how Google OAuth returns responses based on the `prompt` value.

### `select_account`

On this image you can see, that response does not contain `refresh_token` value. Because `select_account` returns `refresh_token` ONLY on first request. Every subsequent requests will come without refresh token.

![no_refresh_token](https://github.com/user-attachments/assets/db65c85d-e1d4-4430-a635-28b44b4796d8)

### `select_account+consent`

On this image you can see, that `refresh_token` is present on every response.

![with_refresh_token](https://github.com/user-attachments/assets/44eb20f4-5e16-4d5c-9ae3-955fbbb15d48)

P.S. you can see `refresh_token_expires_in` value, because my Google OAuth App is in test mode.