### PR TITLE
feat(telegram-bot): add parse mode option for message formatting

### DIFF
--- a/packages/backend/src/apps/telegram-bot/actions/send-message/index.js
+++ b/packages/backend/src/apps/telegram-bot/actions/send-message/index.js
@@ -42,6 +42,20 @@ export default defineAction({
         },
       ],
     },
+    {
+      label: 'Parse Mode',
+      key: 'parseMode',
+      type: 'dropdown',
+      required: false,
+      description: 'Formatting style for the message text.',
+      variables: true,
+      options: [
+        { label: 'None', value: '' },
+        { label: 'Markdown', value: 'Markdown' },
+        { label: 'MarkdownV2', value: 'MarkdownV2' },
+        { label: 'HTML', value: 'HTML' },
+      ],
+    },
   ],
 
   async run($) {
@@ -50,6 +64,11 @@ export default defineAction({
       text: $.step.parameters.text,
       disable_notification: $.step.parameters.disableNotification,
     };
+
+    // Only add parse_mode if set
+    if ($.step.parameters.parseMode) {
+      payload.parse_mode = $.step.parameters.parseMode;
+    }
 
     const response = await $.http.post('/sendMessage', payload);
 


### PR DESCRIPTION
## Description

This PR introduces a new **parse mode option** for the Telegram bot integration, enabling more flexible message formatting when sending messages through the bot. With this enhancement, users can now easily specify the desired parse mode (such as `Markdown`, `MarkdownV2`, or `HTML`) to control how Telegram renders the message content.

## Motivation & Context

Previously, messages sent via the Telegram bot did not provide an option to set the parse mode, limiting formatting capabilities. This update addresses that limitation, allowing for richer, more expressive messages and supporting a wider range of Telegram features.

## Changes

- Added a `parse_mode` option in the Telegram bot action configuration.
- Updated the Telegram action logic to include the `parse_mode` parameter when sending messages via the Telegram API.
- Documented the available parse modes (`Markdown`, `MarkdownV2`, `HTML`) in the action configuration UI/help.

## Screenshots / Demo

![image](https://github.com/user-attachments/assets/ad37365f-de5e-4fd3-9295-ae1090e04e57)
![image](https://github.com/user-attachments/assets/9d868446-c68c-461c-b1c3-6bd8230afa2a)


## Checklist

- [x] Added new `parse_mode` option to Telegram bot configuration
- [x] Updated message sending logic to use the selected parse mode

## Related Issues

https://github.com/automatisch/automatisch/issues/2561

---

Let me know if any further adjustments or clarifications are needed!