### PR TITLE
ci: read the branch name and version input from env instead of interpolating them

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,15 @@ jobs:
     steps:
       - name: Check if this is a release branch
         id: check
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "is-release=true" >> $GITHUB_OUTPUT
-            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+            echo "version=$INPUT_VERSION" >> $GITHUB_OUTPUT
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            BRANCH_NAME="${{ github.head_ref }}"
+            BRANCH_NAME="$HEAD_REF"
             if [[ $BRANCH_NAME =~ ^release/v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
               echo "is-release=true" >> $GITHUB_OUTPUT
               echo "version=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Hi, and thanks for Automatisch.

In `.github/workflows/release.yml`, the "Check if this is a release branch" step puts two pieces of user-supplied text into the shell by interpolation:

```yaml
run: |
  if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
    echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
  elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
    BRANCH_NAME="${{ github.head_ref }}"
```

Actions expands `${{ ... }}` into the script text before bash runs, so both arrive as script rather than as values. Git allows `$`, `(`, `)` and backticks in branch names, and the `workflow_dispatch` version input is free text typed by whoever dispatches — and `$(...)` runs inside double quotes either way.

Worth noting what limits this: the workflow triggers on `pull_request`, not `pull_request_target`, so a fork PR gets a read-only token and no secrets. The `workflow_dispatch` path needs someone who can already dispatch workflows. I am raising it as hardening on a release workflow rather than as a live exploit.

The change binds both values to environment variables:

```yaml
env:
  HEAD_REF: ${{ github.head_ref }}
  INPUT_VERSION: ${{ github.event.inputs.version }}
run: |
  ...
    echo "version=$INPUT_VERSION" >> $GITHUB_OUTPUT
  ...
    BRANCH_NAME="$HEAD_REF"
```

The `^release/v([0-9]+\.[0-9]+\.[0-9]+)$` regex and the `BASH_REMATCH[1]` extraction are untouched, so release detection behaves exactly as before. I left `github.event_name` interpolated deliberately — that is a fixed GitHub-controlled string, not free text.

Disclosure: I used AI assistance to help spot this and prepare the change, and I read the workflow and its triggers myself.
